### PR TITLE
Add Logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "colored"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,6 +148,7 @@ name = "setup-devbox"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "colored",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,6 @@ edition = "2024"
 # We're using 'clap' to easily create command-line interfaces for our application.
 # The 'derive' feature lets us define our command-line arguments right in our Rust code, which is super convenient!
 clap = { version = "4.5.40", features = ["derive"] }
-
+# 'colored' is a fun little crate that lets us add colors to our text in the terminal.
+# It makes our output much easier to read and more engaging!
+colored = "3.0.0"

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,0 +1,52 @@
+use colored::*;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::OnceLock;
+
+/// Macros for logging
+#[macro_export]
+macro_rules! log_info {
+    ($($arg:tt)*) => (println!("{} {}", "[INFO]".on_green(), format!($($arg)*)));
+}
+
+#[macro_export]
+macro_rules! log_warn {
+    ($($arg:tt)*) => (println!("{} {}", "[WARN]".yellow(), format!($($arg)*)));
+}
+
+#[macro_export]
+macro_rules! log_error {
+    ($($arg:tt)*) => (println!("{} {}", "[ERROR]".red(), format!($($arg)*)));
+}
+
+#[macro_export]
+macro_rules! log_debug {
+    ($($arg:tt)*) => {
+        if $crate::logger::is_debug_enabled() {
+            println!("{} {}", "[DEBUG]".blue(), format!($($arg)*));
+        }
+    };
+}
+
+// Atomic flag to track debug mode globally
+static DEBUG_ENABLED: OnceLock<AtomicBool> = OnceLock::new();
+
+/// Initialize logger with debug flag
+pub fn init(debug: bool) {
+    DEBUG_ENABLED
+        .get_or_init(|| AtomicBool::new(debug))
+        .store(debug, Ordering::Relaxed);
+
+    if debug {
+        log_debug!("Logger initialized in DEBUG mode");
+    } else {
+        log_info!("Logger initialized in INFO mode");
+    }
+}
+
+/// Accessor used by macros to check if debug is enabled
+pub fn is_debug_enabled() -> bool {
+    DEBUG_ENABLED
+        .get()
+        .map(|f| f.load(Ordering::Relaxed))
+        .unwrap_or(false)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 mod commands;
-
+mod logger;
 use clap::{Parser, Subcommand};
 use commands::{generate, now, sync, version};
 
@@ -42,6 +42,9 @@ enum Commands {
 
 fn main() {
     let cli = Cli::parse();
+
+    // Initialize logger for project
+    logger::init(cli.debug);
 
     match cli.command {
         Commands::Version => version::run(),


### PR DESCRIPTION
### Add a logger for logging

- Using Macros
- `log_info`, `log_warn`, `log_error` and `log_debug`
- function `is_debug_enabled()` is true if `--debug` is used
- Add colored package for colors