### PR TITLE
Generate command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bitflags"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
 name = "cc"
 version = "1.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +147,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -338,6 +365,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
+name = "libredox"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
 name = "litemap"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,6 +414,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,6 +450,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -524,6 +578,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "colored",
+ "dirs",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -577,6 +632,26 @@ name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+dirs = "6.0.0"
 # We're using 'clap' to easily create command-line interfaces for our application.
 # The 'derive' feature lets us define our command-line arguments right in our Rust code, which is super convenient!
 clap = { version = "4.5.40", features = ["derive"] }

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -1,0 +1,195 @@
+// src/commands/generate.rs
+// This file is all about setting up our initial configuration files.
+// Think of it as the "kickstarter" for a new `setup-devbox` user, providing them with
+// sensible default configuration files so they can hit the ground running.
+
+// We're bringing in a helper function to correctly handle '~' (tilde) in paths,
+// which is a common way users refer to their home directory.
+use crate::utils::expand_tilde;
+// Our custom logging macros to give us nicely formatted (and colored!) output
+// for debugging, general information, and errors.
+use crate::{log_debug, log_error, log_info};
+// The 'colored' crate helps us make our console output look pretty and readable.
+use colored::Colorize;
+// 'std::fs' is our toolkit for interacting with the file system – creating directories, creating files, etc.
+use std::fs;
+// 'std::io::Write' is a trait that allows us to write data to files.
+use std::io::Write;
+// 'std::path::Path' is a powerful type for working with file paths in a robust way.
+use std::path::Path;
+
+// File Names for Our Configuration Templates
+// These constants define the standard names for the configuration files
+// that `setup-devbox` will generate. This keeps our file naming consistent.
+const TOOLS_FILE: &str = "tools.yaml";      // Where users define the software tools they want.
+const SETTINGS_FILE: &str = "settings.yaml"; // Where users define system-level settings (e.g., macOS defaults).
+const SHELLRC_FILE: &str = "shellac.yaml";   // Where users customize their shell environment and aliases.
+const FONTS_FILE: &str = "fonts.yaml";      // Where users list the custom fonts they want installed.
+const CONFIG_FILE: &str = "config.yaml";    // The main configuration file that points to the others.
+
+// Default Configuration Templates (YAML Content)
+// These multi-line string constants hold the default YAML content for each
+// configuration file. These are carefully crafted examples to show users
+// how to structure their configurations and give them immediate working examples.
+
+/// The default content for `tools.yaml`.
+/// It includes examples for installing a GitHub CLI tool ('gh') and `rustup` via Homebrew.
+/// This template is a great starting point for users to understand how to declare tools.
+const TOOLS_TEMPLATE: &str = r#"tools:
+  - name: cli            # The common name of the tool (e.g., 'gh' for GitHub CLI)
+    version: "2.74.0"    # The specific version we recommend as a starting point
+    source: github       # Where to get it from: GitHub releases
+    repo: cli/cli        # The GitHub repository: owner/repo_name
+    tag: v2.74.0         # The specific release tag to download
+    rename_to: gh        # Rename the downloaded executable from 'cli' to 'gh' for convenience
+  - name: rustup         # A popular tool for managing Rust toolchains
+    source: brew         # Get it using the Homebrew package manager (macOS/Linux)
+"#;
+
+/// The default content for `settings.yaml`.
+/// This template provides example macOS settings, such as showing file extensions
+/// and hidden files in Finder, which are common quality-of-life improvements for developers.
+const SETTINGS_TEMPLATE: &str = r#"settings:
+  macos: # Settings specifically for macOS
+    - domain: NSGlobalDomain             # A common domain for global macOS settings
+      key: AppleShowAllExtensions      # The specific setting key: show file extensions
+      value: "true"                    # Set its value to true
+      type: bool                       # This setting expects a boolean value
+    - domain: com.apple.finder           # Settings specific to the macOS Finder application
+      key: AppleShowAllFiles           # The specific setting key: show hidden files
+      value: "true"                    # Set its value to true
+      type: bool                       # This setting also expects a boolean value
+"#;
+
+/// The default content for `shellac.yaml`.
+/// This template demonstrates how to add common `PATH` modifications for development tools
+/// and how to set up command aliases for quick navigation.
+const SHELLRC_TEMPLATE: &str = r#"shellrc:
+  shell: zsh # The type of shell being configured (e.g., zsh, bash, fish)
+  raw_configs: # A list of lines that will be directly added to the shell's config file (e.g., ~/.zshrc)
+    - export PATH=$HOME/bin:$PATH        # Add a custom 'bin' directory to the system PATH
+    - export PATH=$HOME/.cargo/bin:$PATH # Add Rust's cargo binaries to the PATH
+    - export PATH=$HOME/go/bin:$PATH     # Add Go binaries to the PATH
+    - eval "$(starship init zsh)"        # Initialize Starship prompt for a fancy shell prompt
+aliases: # Custom command aliases for user convenience
+  - name: code                           # The short alias name
+    value: cd $HOME/Documents/github/    # The command it expands to: change directory to a common dev folder
+  - name: gocode                         # Another alias for Go development
+    value: cd $HOME/go/src/              # Change directory to the Go source workspace
+"#;
+
+/// The default content for `fonts.yaml`.
+/// This template shows an example of how to declare a custom font for installation,
+/// useful for developers who prefer specific coding fonts like Nerd Fonts.
+const FONTS_TEMPLATE: &str = r#"fonts:
+  - name: 0xProto     # The name of the font
+    version: "2.304"  # A specific version of the font
+    source: github    # Where to get it: GitHub releases
+    repo: ryanoasis/nerd-fonts # The GitHub repo for Nerd Fonts
+    tag: v3.4.0       # The specific release tag for this font version
+"#;
+
+/// This is the master configuration file template: `config.yaml`.
+/// It acts as an index, pointing 'devbox' to the locations of all the other
+/// specialized configuration files. This provides flexibility for users to
+/// organize their config files as they see fit.
+const CONFIG_TEMPLATE: &str = r#"tools: tools.yaml     # Tells devbox where to find the tools configuration
+settings: settings.yaml # Tells devbox where to find the settings configuration
+shellrc: shellac.yaml   # Tells devbox where to find the shell configuration
+fonts: fonts.yaml     # Tells devbox where to find the fonts configuration
+"#;
+
+/// The main entry point for the `generate` command.
+/// This function orchestrates the creation of all the default configuration files
+/// in a specified (or default) directory. It's user-facing and helps them get started.
+///
+/// # Arguments
+/// * `config_dir`: An `Option<String>` that allows the user to specify a custom directory
+///                 for their configuration files. If `None`, a default location is used.
+/// * `_state_path`: (Currently unused, hence the `_`) An `Option<String>` that might
+///                  be used in the future to specify the path to the internal state file.
+pub fn run(config_dir: Option<String>, _state_path: Option<String>) {
+    // Log a detailed debug message about the starting parameters.
+    log_debug!("[Generate] Starting generation with config_dir: {:?}", config_dir);
+
+    // Determine the base directory where config files will be generated.
+    // If the user provided a `config_dir`, use that. Otherwise, default to `~/.setup-devbox/configs/`.
+    let base_dir = config_dir
+        .as_deref() // Convert Option<String> to Option<&str>
+        .unwrap_or("~/.setup-devbox/configs/"); // Default path if none provided
+
+    // Expand the tilde (~) in the path to the actual home directory (e.g., "/Users/youruser/").
+    let base_dir = expand_tilde(base_dir);
+
+    // Inform the user about the chosen configuration directory.
+    log_info!("[Generate] Using config directory: {:?}", base_dir);
+
+    // Check if the base configuration directory already exists.
+    if !base_dir.exists() {
+        // If it doesn't exist, try to create it and all its parent directories.
+        match fs::create_dir_all(&base_dir) {
+            Ok(_) => log_info!("[Generate] Created config directory {:?}", base_dir),
+            Err(e) => {
+                // If directory creation fails, log an error and stop.
+                log_error!("[Generate] Failed to create config directory: {}", e);
+                return; // Exit the function early on failure.
+            }
+        }
+    }
+
+    // Now, let's generate each of the individual configuration files using their templates.
+    // We call a helper function for each file to keep the code clean.
+    generate_file(&base_dir, TOOLS_FILE, TOOLS_TEMPLATE);
+    generate_file(&base_dir, SETTINGS_FILE, SETTINGS_TEMPLATE);
+    generate_file(&base_dir, SHELLRC_FILE, SHELLRC_TEMPLATE);
+    generate_file(&base_dir, FONTS_FILE, FONTS_TEMPLATE);
+
+    // It's important to generate the 'config.yaml' file *last*.
+    // This way, all the individual config files it points to are already in place.
+    generate_file(&base_dir, CONFIG_FILE, CONFIG_TEMPLATE);
+
+    // Finally, let the user know that all the requested config files have been handled.
+    log_info!("[Generate] All requested config files processed.");
+}
+
+/// A helper function to create a single configuration file from a template.
+/// It checks if the file already exists to avoid overwriting user changes.
+///
+/// # Arguments
+/// * `base_dir`: The base directory where the file should be created.
+/// * `filename`: The name of the file to create (e.g., "tools.yaml").
+/// * `content`: The string content (YAML template) to write into the file.
+fn generate_file(base_dir: &Path, filename: &str, content: &str) {
+    // Construct the full path to the file (base_dir + filename).
+    let file_path = base_dir.join(filename);
+
+    // Before creating, let's check if the file already exists.
+    // We don't want to accidentally erase a user's custom configuration!
+    if file_path.exists() {
+        // If it exists, we just log a message and skip creating it.
+        log_info!("[Generate] Skipping existing file {:?}. We don't want to overwrite your changes!", file_path);
+        return; // Exit this helper function.
+    }
+
+    // If the file doesn't exist, we'll proceed to create it.
+    log_info!("[Generate] Creating new file {:?}", file_path);
+
+    // Attempt to create the file.
+    match fs::File::create(&file_path) {
+        // If file creation is successful, we get a `File` handle.
+        Ok(mut file) => {
+            // Now, try to write the template content into the newly created file.
+            if let Err(e) = file.write_all(content.as_bytes()) {
+                // If writing fails (e.g., permissions issue), log an error.
+                log_error!("[Generate] Oh no! Failed to write to {:?}: {}", file_path, e);
+            } else {
+                // Success! The file was written.
+                log_info!("[Generate] Successfully wrote default content to {:?}", file_path);
+            }
+        }
+        // If file creation itself fails (e.g., directory permissions), log an error.
+        Err(e) => {
+            log_error!("[Generate] Couldn't create file {:?}: {}", file_path, e);
+        }
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,2 +1,3 @@
 // Register version commands
 pub mod version;
+pub mod generate;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,8 @@
 mod commands;
 mod logger;
+mod utils;
+mod schema;
+
 use clap::{Parser, Subcommand};
 use commands::{generate, now, sync, version};
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,0 +1,246 @@
+// src/schema.rs
+// This file is essentially the blueprint for all the different configuration files
+// and the internal state that our `setup-devbox` application will use.
+// Think of it as defining the "language" for how we describe tools, settings, fonts, and more!
+
+// We're bringing in 'serde' traits here.
+// 'Deserialize' means we can take data from external files (like YAML or JSON)
+// and turn it into these Rust structures.
+// 'Serialize' means we can take our Rust structures and write them out to files.
+use serde::{Deserialize, Serialize};
+// 'HashMap' is a super useful data structure from Rust's standard library.
+// It allows us to store data as key-value pairs, which is perfect for
+// things like looking up tools by their name, or organizing settings by OS.
+use std::collections::HashMap;
+
+// GitHub API Response Schemas
+// These two structs are specifically designed to match the JSON response we get back
+// when querying the GitHub API for release information.
+
+/// This struct represents a single downloadable file (an "asset") attached to a GitHub release.
+/// When we ask GitHub for the details of a software release, it often lists multiple files
+/// that you can download (like different versions for Windows, macOS, Linux, etc.).
+#[derive(Debug, Deserialize)] // We derive 'Debug' to easily print its contents for debugging,
+// and 'Deserialize' to parse it from GitHub's JSON.
+pub struct ReleaseAsset {
+    // The actual name of the file, e.g., "my-tool-macos-amd64.tar.gz".
+    pub(crate) name: String,
+    // This is the direct URL you'd use in your browser (or with an HTTP client!)
+    // to download this specific file. Super handy!
+    pub(crate) browser_download_url: String,
+}
+
+/// This struct captures the overall details of a single GitHub release.
+/// A release often contains a collection of assets (the actual downloadable files).
+#[derive(Debug, Deserialize)] // Again, 'Debug' for introspection and 'Deserialize' for JSON parsing.
+pub struct Release {
+    // This `Vec` (which is Rust's way of saying "vector" or dynamic array)
+    // will hold a list of all the `ReleaseAsset`s available for this particular release.
+    // It's like a shopping list of all the files bundled with this version.
+    pub(crate) assets: Vec<ReleaseAsset>,
+}
+
+// User Configuration File Schemas (e.g., for YAML files)
+// These structs define the structure for the configuration files that our users will write
+// to tell `setup-devbox` what tools, settings, and fonts they want managed.
+
+/// Configuration schema for `tools.yaml`.
+/// This is the top-level structure for the file where users list all the software tools
+/// they want `setup-devbox` to manage and install for them.
+#[derive(Debug, Serialize, Deserialize)] // We need both 'Serialize' and 'Deserialize' because
+// we'll read these from a file and potentially write them too (though less common for config).
+pub struct ToolConfig {
+    // This `tools` field will hold a list of individual `ToolEntry` structs.
+    // Each `ToolEntry` describes one specific tool the user wants.
+    pub tools: Vec<ToolEntry>,
+}
+
+/// Represents a single tool entry as defined by the user in the `tools.yaml` file.
+/// This is where the user specifies *which* tool, *what version*, and *how* to get it.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ToolEntry {
+    // The human-readable name of the tool (e.g., "terraform", "kubectl").
+    pub name: String,
+    // The desired version of the tool. It's an `Option<String>` because the user
+    // might not specify a version, in which case we'd probably try to get the latest.
+    pub version: Option<String>,
+    // This crucial field tells `setup-devbox` *where* to get the tool from.
+    // Examples: "github", "brew" (for Homebrew), "go" (for Go binaries), "cargo" (for Rust crates).
+    pub source: String,
+    // If the `source` is "github", this `Option<String>` holds the GitHub repository
+    // in the "owner/repo_name" format (e.g., "hashicorp/terraform").
+    pub repo: Option<String>,
+    // Sometimes, a specific release on GitHub isn't directly the version number,
+    // but rather a tag name. This field allows specifying a particular tag to download from.
+    pub tag: Option<String>,
+    // If the downloaded executable has a generic name (e.g., "cli") but the user
+    // wants it to be called something specific (e.g., "mycli"), this field allows renaming.
+    pub rename_to: Option<String>,
+}
+
+/// Configuration schema for `shellac.yaml`.
+/// This file is all about customizing the user's shell environment,
+/// including shell-specific configurations and command aliases.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ShellConfig {
+    // This block describes the core shell configuration, like the shell type and raw commands.
+    pub shellrc: ShellRc,
+    // This `Vec` will contain a list of custom command aliases the user wants to set up.
+    pub aliases: Vec<AliasEntry>,
+}
+
+/// Represents the `shellrc` block within `shellac.yaml`.
+/// This section is for fundamental shell settings that might be different for Bash, Zsh, etc.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ShellRc {
+    // The type of shell being configured (e.g., "bash", "zsh", "fish").
+    pub shell: String,
+    // A list of raw command lines that will be directly appended or sourced into the shell's
+    // configuration file (like `.bashrc` or `.zshrc`). This allows for highly custom setups.
+    pub raw_configs: Vec<String>,
+}
+
+/// Represents a single command alias entry in `shellac.yaml`.
+/// Aliases are shortcuts for longer commands, making life easier in the terminal.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AliasEntry {
+    // The short name for the alias (e.g., "gco").
+    pub name: String,
+    // The full command that the alias expands to (e.g., "git checkout").
+    pub value: String,
+}
+
+/// Configuration schema for `fonts.yaml`.
+/// This file lets users specify custom fonts they want `setup-devbox` to manage and install.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FontConfig {
+    // This `Vec` will hold a list of individual `FontEntry` structs, each describing one font.
+    pub fonts: Vec<FontEntry>,
+}
+
+/// Represents a single font entry as defined by the user in `fonts.yaml`.
+/// Similar to `ToolEntry`, it describes what font, what version, and where to get it.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FontEntry {
+    // The name of the font (e.g., "FiraCode", "JetBrainsMono").
+    pub name: String,
+    // The desired version of the font. Often fonts don't have explicit versions like software,
+    // but it's good to include for consistency or specific releases.
+    pub version: Option<String>,
+    // The source from where the font can be obtained (e.g., "github", "nerdfonts").
+    pub source: String,
+    // If the `source` is "github", this is the repository (e.g., "ryanoasis/nerd-fonts").
+    pub repo: Option<String>,
+    // A specific tag or release on GitHub to download the font from.
+    pub tag: Option<String>,
+}
+
+/// Configuration schema for `settings.yaml`.
+/// This file allows users to define system-level settings (e.g., macOS defaults)
+/// that 'devbox' should apply.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SettingsConfig {
+    // This is a `HashMap` where the key is the operating system (e.g., "macos", "linux")
+    // and the value is a list of `SettingEntry` structs. This allows users to
+    // specify OS-specific settings.
+    pub settings: HashMap<String, Vec<SettingEntry>>, // Key: OS name (e.g., "macos"), Value: List of settings for that OS
+}
+
+/// Represents a single system setting to be applied, typically for macOS defaults commands.
+/// This allows for granular control over system behavior.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SettingEntry {
+    // The domain of the setting (e.g., "com.apple.finder" for Finder settings).
+    pub domain: String,
+    // The specific key within that domain (e.g., "AppleShowAllFiles" to show hidden files).
+    pub key: String,
+    // The value to set for that key (e.g., "true", "false", "Always").
+    pub value: String,
+    // This is a special field! `#[serde(rename = "type")]` tells Serde to expect a key
+    // named "type" in the YAML/JSON, even though our Rust field is called `value_type`.
+    // This is often done when the external format uses a keyword that's reserved in Rust.
+    // This field specifies the data type of the `value` (e.g., "string", "bool", "integer").
+    #[serde(rename = "type")]
+    pub value_type: String,
+}
+
+// Application State File Schema (state.json)
+// These structs define the structure of `setup-devbox` internal state file (`state.json`).
+// This file is crucial for `setup-devbox` to remember what it has installed and configured,
+// so it doesn't try to re-install things or re-apply settings unnecessarily.
+
+/// The complete structure of `state.json`, which acts as `setup-devbox's` memory.
+/// It records everything `setup-devbox` has done – what tools are installed, settings applied, etc.
+/// 'Clone' is derived here because we might need to easily duplicate this state object in memory.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct DevBoxState {
+    // A `HashMap` to keep track of all installed tools.
+    // The key is likely the tool's name, and the value is its `ToolState` details.
+    pub tools: HashMap<String, ToolState>,
+    // A `HashMap` to record which settings have been applied.
+    // The key could be a combination of domain and key, or just the domain, and the value is its `SettingState`.
+    pub settings: HashMap<String, SettingState>,
+    // A `HashMap` to store information about installed fonts.
+    // Key: font name, Value: `FontState` details.
+    pub fonts: HashMap<String, FontState>,
+}
+
+/// Stores detailed information about each tool that `setup-devbox` has successfully installed.
+/// This helps `setup-devbox` know if a tool is already there, where it is, and how it was installed.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ToolState {
+    // The exact version of the tool that was installed.
+    pub version: String,
+    // The file system path where the tool's executable or main directory is located.
+    pub install_path: String,
+    // A boolean flag indicating whether this tool was installed by `setup-devbox` itself.
+    // This is useful for distinguishing between tools `setup-devbox` manages and those installed manually.
+    pub installed_by_devbox: bool,
+    // The method used to install the tool (e.g., "github-release", "brew", "go-install").
+    pub install_method: String,
+    // If the tool's executable was renamed during installation, this stores the new name.
+    pub renamed_to: Option<String>,
+    // The type of package (e.g., "binary", "go-module", "brew-formula").
+    pub package_type: String,
+}
+
+/// Records the state of a single system setting that `setup-devbox` has applied.
+/// This helps `setup-devbox` avoid re-applying settings that are already in place.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SettingState {
+    // The domain of the setting (e.g., "com.apple.finder").
+    pub domain: String,
+    // The specific key of the setting (e.g., "AppleShowAllFiles").
+    pub key: String,
+    // The value that was set for this key.
+    pub value: String,
+    // Note: The `value_type` from `SettingEntry` isn't stored here.
+    // The state just records *what* was set, assuming the type was handled during application.
+}
+
+/// Records the state of a single font that `setup-devbox` has installed.
+/// This helps `setup-devbox` know which fonts are managed and where they came from.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct FontState {
+    // The name of the font (e.g., "FiraCode Nerd Font").
+    pub name: String,
+    // The original URL from which the font was downloaded. Useful for re-downloads or verification.
+    pub url: String,
+    // A list of the actual font files (e.g., .ttf, .otf) that were installed for this font.
+    pub files: Vec<String>,
+}
+
+/// This struct defines the main configuration file for the `setup-devbox` application itself.
+/// It tells `setup-devbox` *where* to find the other detailed configuration files (tools, settings, etc.).
+/// This allows for a flexible file structure where users can organize their configs.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MainConfig {
+    // An optional path to the `tools.yaml` file. If not specified, 'devbox' might look for a default.
+    pub tools: Option<String>,
+    // An optional path to the `settings.yaml` file.
+    pub settings: Option<String>,
+    // An optional path to the `shellac.yaml` file (for shell configs and aliases).
+    pub shellrc: Option<String>,
+    // An optional path to the `fonts.yaml` file.
+    pub fonts: Option<String>,
+}

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -67,7 +67,7 @@ pub struct ToolEntry {
     // This crucial field tells `setup-devbox` *where* to get the tool from.
     // Examples: "github", "brew" (for Homebrew), "go" (for Go binaries), "cargo" (for Rust crates).
     pub source: String,
-    // If the `source` is "github", this `Option<String>` holds the GitHub repository
+    // If the `source` is "GitHub", this `Option<String>` holds the GitHub repository
     // in the "owner/repo_name" format (e.g., "hashicorp/terraform").
     pub repo: Option<String>,
     // Sometimes, a specific release on GitHub isn't directly the version number,
@@ -129,7 +129,7 @@ pub struct FontEntry {
     pub version: Option<String>,
     // The source from where the font can be obtained (e.g., "github", "nerdfonts").
     pub source: String,
-    // If the `source` is "github", this is the repository (e.g., "ryanoasis/nerd-fonts").
+    // If the `source` is "GitHub", this is the repository (e.g., "ryanoasis/nerd-fonts").
     pub repo: Option<String>,
     // A specific tag or release on GitHub to download the font from.
     pub tag: Option<String>,
@@ -137,7 +137,7 @@ pub struct FontEntry {
 
 /// Configuration schema for `settings.yaml`.
 /// This file allows users to define system-level settings (e.g., macOS defaults)
-/// that 'devbox' should apply.
+/// that `setup-devbox` should apply.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SettingsConfig {
     // This is a `HashMap` where the key is the operating system (e.g., "macos", "linux")
@@ -165,11 +165,11 @@ pub struct SettingEntry {
 }
 
 // Application State File Schema (state.json)
-// These structs define the structure of `setup-devbox` internal state file (`state.json`).
+// These structs define the structure of `setup-devbox`s internal state file (`state.json`).
 // This file is crucial for `setup-devbox` to remember what it has installed and configured,
 // so it doesn't try to re-install things or re-apply settings unnecessarily.
 
-/// The complete structure of `state.json`, which acts as `setup-devbox's` memory.
+/// The complete structure of `state.json`, which acts as `setup-devbox`s memory.
 /// It records everything `setup-devbox` has done – what tools are installed, settings applied, etc.
 /// 'Clone' is derived here because we might need to easily duplicate this state object in memory.
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -230,12 +230,14 @@ pub struct FontState {
     pub files: Vec<String>,
 }
 
+//  Main Application Configuration
+
 /// This struct defines the main configuration file for the `setup-devbox` application itself.
 /// It tells `setup-devbox` *where* to find the other detailed configuration files (tools, settings, etc.).
 /// This allows for a flexible file structure where users can organize their configs.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MainConfig {
-    // An optional path to the `tools.yaml` file. If not specified, 'devbox' might look for a default.
+    // An optional path to the `tools.yaml` file. If not specified, `setup-devbox` might look for a default.
     pub tools: Option<String>,
     // An optional path to the `settings.yaml` file.
     pub settings: Option<String>,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,11 @@
+use std::path::PathBuf;
+
+/// Expand tilde (~) in paths to the user's home directory.
+pub fn expand_tilde(path: &str) -> PathBuf {
+    if path.starts_with("~") {
+        if let Some(home) = dirs::home_dir() {
+            return PathBuf::from(path.replacen("~", &home.to_string_lossy(), 1));
+        }
+    }
+    PathBuf::from(path)
+}


### PR DESCRIPTION
### Adding `generate` command

- It will generate default configuration files (`tools.yaml`, `fonts.yaml`, `settings.yaml`, `shellrc.yaml` and `config.yaml`
- Default path for configuration files are `$HOME/.setup-devbox/config/`
- Adding `utils` module for housekeeping methods and functions
- Added `expand_tilde` function to expand `~`