### PR TITLE
Sync command implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,19 +70,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "arbitrary"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
-dependencies = [
- "derive_arbitrary",
-]
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "bitflags"
@@ -100,10 +97,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.19.0"
+name = "byteorder"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
 
 [[package]]
 name = "bzip2"
@@ -112,6 +119,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bea8dcd42434048e4f7a304411d9273a411f647446c1234a65ce0554923f4cff"
 dependencies = [
  "libbz2-rs-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -198,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "constant_time_eq"
-version = "0.3.1"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "cpufeatures"
@@ -221,6 +238,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,29 +254,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "deflate64"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b"
-
-[[package]]
 name = "deranged"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
-]
-
-[[package]]
-name = "derive_arbitrary"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -334,7 +340,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
- "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -562,26 +567,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
-name = "liblzma"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0791ab7e08ccc8e0ce893f6906eb2703ed8739d8e89b57c0714e71bad09024c8"
-dependencies = [
- "liblzma-sys",
-]
-
-[[package]]
-name = "liblzma-sys"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b9596486f6d60c3bbe644c0e1be1aa6ccc472ad630fe8927b456973d7cb736"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "libredox"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,15 +575,6 @@ dependencies = [
  "bitflags",
  "libc",
  "redox_syscall",
-]
-
-[[package]]
-name = "libz-rs-sys"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "172a788537a2221661b480fee8dc5f96c580eb34fa88764d3205dc356c7e4221"
-dependencies = [
- "zlib-rs",
 ]
 
 [[package]]
@@ -659,13 +635,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
-name = "pbkdf2"
-version = "0.12.2"
+name = "password-hash"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
  "digest",
  "hmac",
+ "password-hash",
+ "sha2",
 ]
 
 [[package]]
@@ -696,12 +685,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "ppmd-rust"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c834641d8ad1b348c9ee86dec3b9840d805acd5f24daa5f90c788951a52ff59b"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,6 +707,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "redox_syscall"
@@ -880,7 +869,7 @@ dependencies = [
 name = "setup-devbox"
 version = "0.1.0"
 dependencies = [
- "bzip2",
+ "bzip2 0.6.0",
  "clap",
  "colored",
  "dirs",
@@ -907,16 +896,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "simd-adler32"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "smallvec"
@@ -1349,20 +1343,6 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "zerotrie"
@@ -1399,64 +1379,40 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "4.3.0"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aed4ac33e8eb078c89e6cbb1d5c4c7703ec6d299fc3e7c3695af8f8b423468b"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
 dependencies = [
  "aes",
- "arbitrary",
- "bzip2",
+ "byteorder",
+ "bzip2 0.4.4",
  "constant_time_eq",
  "crc32fast",
- "deflate64",
+ "crossbeam-utils",
  "flate2",
- "getrandom 0.3.3",
  "hmac",
- "indexmap",
- "liblzma",
- "memchr",
  "pbkdf2",
- "ppmd-rust",
  "sha1",
  "time",
- "zeroize",
- "zopfli",
  "zstd",
 ]
 
 [[package]]
-name = "zlib-rs"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626bd9fa9734751fc50d6060752170984d7053f5a39061f524cda68023d4db8a"
-
-[[package]]
-name = "zopfli"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edfc5ee405f504cd4984ecc6f14d02d55cfda60fa4b689434ef4102aae150cd7"
-dependencies = [
- "bumpalo",
- "crc32fast",
- "log",
- "simd-adler32",
-]
-
-[[package]]
 name = "zstd"
-version = "0.13.3"
+version = "0.11.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "7.2.4"
+version = "5.0.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
 dependencies = [
+ "libc",
  "zstd-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,35 +1,83 @@
+# Cargo.toml
+
+# This section defines fundamental information about your Rust project,
+# similar to how a package.json works for Node.js or a pom.xml for Java.
 [package]
+# 'name' is the name of your executable binary and the package itself.
+# This is how you'll typically run your application (e.g., `cargo run --bin setup-devbox`).
 name = "setup-devbox"
+# 'version' follows Semantic Versioning (Major.Minor.Patch).
+# It indicates the current release version of your application.
 version = "0.1.0"
+# 'edition' specifies the Rust edition to use for compiling this package.
+# Rust editions allow the language to evolve without breaking existing code.
+# "2024" is a newer edition that enables modern Rust features and syntax.
 edition = "2024"
 
+# This section lists all the external crates (libraries) that your project depends on.
+# Cargo automatically downloads, compiles, and links these dependencies for you.
 [dependencies]
+# 'dirs' is a handy cross-platform utility crate for finding common user directories.
+# This is super useful for locating things like the user's home directory, config directory,
+# or data directory, which are essential for storing application-specific files (like state.json or configs).
 dirs = "6.0.0"
-# We're using 'clap' to easily create command-line interfaces for our application.
+
+# 'clap' is a powerful and flexible crate for parsing command-line arguments.
+# It makes it easy to define subcommands, options, and flags for your CLI application.
 # The 'derive' feature lets us define our command-line arguments right in our Rust code, which is super convenient!
-clap = { version = "4.5.40", features = ["derive"] }
+# 'version' specifies the exact version of the clap crate to use.
+# 'features = ["derive"]' enables declarative argument parsing using Rust's derive macros.
+clap = { version = "4.5.41", features = ["derive"] }
+
 # 'colored' is a fun little crate that lets us add colors to our text in the terminal.
 # It makes our output much easier to read and more engaging!
 colored = "3.0.0"
+
 # 'serde' is like the universal translator for Rust data structures.
 # It helps us convert our Rust data into various formats (like JSON or YAML) and vice-versa.
 # The 'derive' feature gives us handy macros to automatically implement serialization/deserialization.
+# 'version' specifies the exact version of the serde core library.
+# 'features = ["derive"]' provides macros like `#[derive(Serialize, Deserialize)]`.
 serde = { version = "1.0.219", features = ["derive"] }
+
 # 'serde_yaml' specifically handles converting Rust data to and from the YAML format.
 # We often use YAML for configuration files because it's quite human-readable.
-serde_yaml = "0.9.34+deprecated"
+serde_yaml = "0.9.34"
+
 # 'serde_json' is another specialized part of the Serde family, but this one focuses on JSON.
 # JSON is a very common format for web APIs and data exchange.
 serde_json = "1.0.140"
+
 # 'toml' is a crate for working with TOML files, which are often used for Rust project configurations
 # (like our Cargo.toml!). It helps us read and write data in this format.
-toml = "0.9.0"
+toml = "0.9.1"
+
 # 'ureq' is a simple and easy-to-use HTTP client.
 # It's what we'll use to make requests to web services (like GitHub's API).
 # The 'json' feature adds convenience for handling JSON responses automatically.
-ureq = { version = "2.0.0", features = ["json"] }
+# 'version' specifies the exact version of the ureq crate.
+# 'features = ["json"]' adds convenience methods for sending and receiving JSON data in HTTP requests.
+ureq = { version = "2.12.1", features = ["json"] }
+
+# 'flate2' is a Rust binding to compression libraries (`miniz_oxide` and `zlib`).
+# It's essential for handling common compression formats like Gzip, often found in `.tar.gz` archives.
 flate2 = "1.1.2"
+
+# 'tar' is a crate for creating, reading, and extracting `.tar` archives.
+# These archives are commonly used on Unix-like systems to bundle multiple files into one.
+# It's often used in conjunction with a compression library like `flate2` or `bzip2`.
 tar = "0.4.44"
-zip = "4.3.0"
+
+# 'zip' is a library for working with `.zip` archives.
+# Zip files are another popular format for bundling and compressing files, especially common on Windows.
+zip = "0.6.0"
+
+# 'bzip2' provides bindings to the `bzip2` compression library.
+# This crate allows your application to handle `.bz2` compressed files and `.tar.bz2` archives.
+# Since it's a direct dependency here, it will always be compiled into your application.
 bzip2 = "0.6.0"
+
+# 'walkdir' is a utility for recursively walking a directory tree.
+# This is useful for tasks like finding all files within a directory,
+# or cleaning up temporary directories after installations.
 walkdir = "2.5.0"

--- a/src/commands/now.rs
+++ b/src/commands/now.rs
@@ -253,7 +253,7 @@ pub fn run(config_path: Option<String>, state_path: Option<String>) {
                 // If we can't read the master config file (e.g., it's missing, permissions are off, or corrupted),
                 // we log a critical error and halt execution. We simply can't proceed without our master plan!
                 log_error!(
-                    "Failed to read main config.yaml at {:?}: {}. Please ensure the file exists and is readable.",
+                    "Failed to read main config.yaml at {}: {}. Please ensure the file exists and is readable.",
                     config_path_resolved.display().to_string().red(),
                     e
                 );

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -1,7 +1,194 @@
-// Bring in our custom logging macros for debug, error, info, and warning messages.
-use crate::log_info;
-// For adding color to our terminal output (makes logs easier to read!).
+use crate::schema::{
+    FontConfig, // Core state and main config
+    FontEntry, MainConfig, SettingEntry, SettingsConfig, ToolConfig, ToolEntry
+};
+use crate::utils::{
+    get_devbox_dir,
+    read_devbox_state
+};
+use crate::{
+    log_debug,
+    log_error,
+    log_info,
+    log_warn
+};
+use clap::Args;
 use colored::Colorize;
-pub fn run(state: Option<String>) {
-    log_info!("Starting sync...[Placeholder] for sync commands...");
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Arguments for the `sync config` subcommand.
+///
+/// `#[derive(Debug, Args)]` tells Clap to generate argument parsing for these arguments.
+#[derive(Debug, Args)]
+pub struct SyncConfigArgs {
+    /// Path to the DevBox state file.
+    /// Defaults to `~/.setup-devbox/state.json`.
+    #[arg(long)]
+    pub state: Option<PathBuf>,
+    /// Path to the directory where config files should be generated.
+    /// Defaults to `~/.setup-devbox/configs/`.
+    #[arg(long)]
+    pub output_dir: Option<PathBuf>,
+}
+
+pub fn run(args: SyncConfigArgs) {
+    eprint!("\n"); // Add a blank line for readability.
+    log_warn!("{}", "[Sync] This 'sync' command is an EMERGENCY command and should be avoided if possible.".bold());
+    log_warn!("{}", "[Sync] It is primarily for recovering or generating configuration from/to the state.".bold());
+    log_warn!("{}", "[Sync] Please use the 'now' command for regular setup and updates.".bold());
+    eprint!("\n"); // Add another blank line.
+
+    // Define default paths based on the `~/.setup-devbox` directory
+    let devbox_dir = get_devbox_dir();
+    let default_state_path = devbox_dir.join("state.json");
+    let default_config_dir = devbox_dir.join("configs");
+    
+    // The logic below now directly executes sync_state_to_configs.
+    // This was previously inside the `SyncCommands::SyncConfig(args)` arm.
+    log_info!("[Sync] Syncing config files from state file.");
+    let state_path = args.state.unwrap_or(default_state_path);
+    let output_dir = args.output_dir.unwrap_or(default_config_dir);
+    log_debug!("[Sync] Syncing from state: {}", state_path.display());
+    log_debug!("[Sync] Outputting to config directory: {}", output_dir.display());
+    sync_state_to_configs(&state_path, &output_dir);
+    log_info!("[Sync] Synchronization process completed.");
+}
+
+// Helper function to write data of type `T` to a YAML file.
+fn write_yaml_file<T: serde::Serialize>(path: &PathBuf, data: &T) -> Result<(), String> {
+    log_debug!("[Sync:File] Writing YAML file: {}", path.display().to_string().cyan());
+    // Ensure the parent directory exists before writing the file
+    fs::create_dir_all(path.parent().unwrap_or(Path::new(".")))
+        .map_err(|e| format!("Failed to create directory for {}: {}", path.display(), e))?;
+    let content = serde_yaml::to_string(data)
+        .map_err(|e| format!("Failed to serialize data to YAML for {}: {}", path.display(), e))?;
+    fs::write(path, content)
+        .map_err(|e| format!("Failed to write to {}: {}", path.display(), e))?;
+    Ok(())
+}
+
+/// Synchronizes configuration files from a DevBox state file.
+/// This function reads the `DevBoxState` and generates `config.yaml`, `tools.yaml`,
+/// `settings.yaml`, and `fonts.yaml` based on its contents.
+fn sync_state_to_configs(state_path: &PathBuf, output_dir: &PathBuf) {
+    log_info!("[Sync:Config] Attempting to sync config files from state: {}", state_path.display().to_string().cyan());
+
+    // 1. Read the DevBoxState from the specified path
+    let devbox_state = match read_devbox_state(state_path) {
+        Ok(state) => state,
+        Err(e) => {
+            log_error!("[Sync:Config] Failed to read DevBox state from {}: {}", state_path.display().to_string().red(), e);
+            return; // Exit if state cannot be read
+        }
+    };
+
+    log_info!("[Sync:Config] DevBox state loaded. Generating config files in: {}", output_dir.display().to_string().green());
+
+    // 2. Ensure the output directory exists
+    if let Err(e) = fs::create_dir_all(output_dir) {
+        log_error!("[Sync:Config] Failed to create output directory {}: {}", output_dir.display().to_string().red(), e);
+        return; // Exit if directory cannot be created
+    }
+
+    // Prepare vectors/maps to hold the converted config structs
+    let mut tools_entries: Vec<ToolEntry> = Vec::new();
+    let mut settings_entries_by_os: HashMap<String, Vec<SettingEntry>> = HashMap::new();
+    let mut fonts_entries: Vec<FontEntry> = Vec::new();
+
+    // 3. Convert ToolState entries to ToolEntry
+    // Fix applied here: Use `tool_name` (the HashMap key) for `ToolEntry.name`
+    for (tool_name, tool_state) in devbox_state.tools {
+        tools_entries.push(ToolEntry {
+            name: tool_name, // Use the key from the HashMap as the tool's name
+            version: Some(tool_state.version), // `ToolState.version` maps to `ToolEntry.version`
+            source: tool_state.install_method, // `ToolState.install_method` maps to `ToolEntry.source`
+            repo: tool_state.repo,
+            tag: tool_state.tag,
+            rename_to: tool_state.renamed_to, // Maps directly
+        });
+    }
+    let tool_config = ToolConfig { tools: tools_entries };
+
+
+    // 4. Convert SettingState entries to SettingEntry
+    // Note: This conversion is lossy. SettingState doesn't have an OS key,
+    // and SettingEntry requires `value_type`.
+    // Assumption: Group all settings under a "macos" key for generation.
+    let mut macos_settings: Vec<SettingEntry> = Vec::new();
+    for (_, setting_state) in devbox_state.settings {
+        macos_settings.push(SettingEntry {
+            domain: setting_state.domain,
+            key: setting_state.key,
+            value: setting_state.value,
+            value_type: "string".to_string(), // Placeholder, cannot infer actual type
+        });
+    }
+    settings_entries_by_os.insert("macos".to_string(), macos_settings);
+    let settings_config = SettingsConfig { settings: settings_entries_by_os };
+
+
+    // 5. Convert FontState entries to FontEntry
+    // Note: This conversion is lossy, as FontEntry has `repo`, `tag` which are not in FontState.
+    // `FontState.url` maps to `FontEntry.source`.
+    for (_, font_state) in devbox_state.fonts {
+        // Determine the 'source' for FontEntry based on FontState's URL
+        let source_type = if font_state.url.contains("github.com") && font_state.url.contains("/releases/") {
+            // If the URL is from GitHub releases, set the source as "GitHub"
+            "github".to_string()
+        } else {
+            // Otherwise, use the full URL as the source
+            font_state.url.clone()
+        };
+        fonts_entries.push(FontEntry {
+            name: font_state.name,
+            version: Some(font_state.version),
+            source: source_type,
+            repo: font_state.repo,
+            tag: font_state.tag,
+        });
+    }
+    let font_config = FontConfig { fonts: fonts_entries };
+
+
+    // 6. Write the individual YAML configuration files
+    let tools_yaml_path = output_dir.join("tools.yaml");
+    if let Err(e) = write_yaml_file(&tools_yaml_path, &tool_config) {
+        log_error!("[Sync:Config] Failed to write tools.yaml to {}: {}", tools_yaml_path.display().to_string().red(), e);
+    } else {
+        log_info!("[Sync:Config] tools.yaml generated at {}.", tools_yaml_path.display().to_string().green());
+    }
+
+    let settings_yaml_path = output_dir.join("settings.yaml");
+    if let Err(e) = write_yaml_file(&settings_yaml_path, &settings_config) {
+        log_error!("[Sync:Config] Failed to write settings.yaml to {}: {}", settings_yaml_path.display().to_string().red(), e);
+    } else {
+        log_info!("[Sync:Config] settings.yaml generated at {}.", settings_yaml_path.display().to_string().green());
+    }
+
+    let fonts_yaml_path = output_dir.join("fonts.yaml");
+    if let Err(e) = write_yaml_file(&fonts_yaml_path, &font_config) {
+        log_error!("[Sync:Config] Failed to write fonts.yaml to {}: {}", fonts_yaml_path.display().to_string().red(), e);
+    } else {
+        log_info!("[Sync:Config] fonts.yaml generated at {}.", fonts_yaml_path.display().to_string().green());
+    }
+
+    // 7. Create and write the main config.yaml, referencing the generated files
+    // Paths are relative to the `output_dir` for MainConfig.
+    let main_config = MainConfig {
+        tools: Some(tools_yaml_path.to_str().unwrap().to_string()),
+        settings: Some(settings_yaml_path.to_str().unwrap().to_string()),
+        fonts: Some(fonts_yaml_path.to_str().unwrap().to_string()),
+        shellrc: None, // ShellRC file content is not preserved in the state-file, so null
+    };
+
+    let main_config_path = output_dir.join("config.yaml");
+    if let Err(e) = write_yaml_file(&main_config_path, &main_config) {
+        log_error!("[Sync:Config] Failed to write config.yaml to {}: {}", main_config_path.display().to_string().red(), e);
+    } else {
+        log_info!("[Sync:Config] config.yaml generated at {}.", main_config_path.display().to_string().green());
+    }
+
+    log_info!("[Sync:Config] Configuration files generation complete.");
 }

--- a/src/installers/brew.rs
+++ b/src/installers/brew.rs
@@ -118,5 +118,11 @@ pub fn install(tool: &ToolEntry) -> Option<ToolState> {
         renamed_to: tool.rename_to.clone(),
         // We can denote the package type as "brew" for consistency.
         package_type: "brew".to_string(),
+        // Not required for `Homebrew` installations
+        // This is just placeholder for symmetry
+        repo: Option::from("UNKNOWN_FROM_CONFIG".to_string()),
+        // Not required for `Homebrew` installations
+        // This is just placeholder for symmetry
+        tag: Option::from("UNKNOWN_FROM_CONFIG".to_string()),
     })
 }

--- a/src/installers/fonts.rs
+++ b/src/installers/fonts.rs
@@ -146,7 +146,7 @@ pub fn install(font: &FontEntry) -> Option<FontState> {
 
     // Extract the contents of the downloaded ZIP archive into another specific
     // subdirectory within the temporary directory. This keeps extracted files organized.
-    let extracted_dir = match utils::extract_archive(&archive_path, &temp_dir, Some(&file_type_from_name)) { // <--- PASS KNOWN TYPE HERE
+    let extracted_dir = match utils::extract_archive(&archive_path, &temp_dir, Some(&file_type_from_name)) {
         Ok(path) => path, // If extraction is successful, `path` is the directory where contents were placed.
         Err(err) => {
             // If extraction fails, log the error.
@@ -331,7 +331,14 @@ pub fn install(font: &FontEntry) -> Option<FontState> {
             // Prioritize the `version` field from `FontEntry`. If not present, fall back to the `tag`.
             // If neither is present (should be caught by earlier validation for 'tag'), use "unknown".
             version: font.version.clone().unwrap_or_else(|| font.tag.clone().unwrap_or_else(|| "unknown".to_string())),
-            url, // Store the exact URL from which the font archive was downloaded.
+            // Store the exact URL from which the font archive was downloaded.
+            url,
+            // Record the repository name
+            // Helps in `sync` command
+            repo: font.repo.clone(),
+            // Record the tag name
+            // Helps in `sync` command
+            tag: font.tag.clone(),
             files: installed_font_files, // Store the list of absolute paths to the installed font files.
         })
     } else {

--- a/src/installers/github.rs
+++ b/src/installers/github.rs
@@ -263,6 +263,12 @@ pub fn install(tool: &ToolEntry) -> Option<ToolState> {
         install_method: "github".to_string(),
         // Record if the binary was renamed during installation.
         renamed_to: tool.rename_to.clone(),
+        // Record the repository name 
+        // Help in `sync` command to sync back
+        repo: tool.repo.clone(),
+        // Record the tag name 
+        // Help in `sync` command to sync back
+        tag: tool.tag.clone(),
         // Store the type of package that was downloaded and processed.
         // We now use the `actual_file_type_for_state` which still uses the `file` command
         // for recording the most "truthful" type for diagnostics, even if we used

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,10 @@ mod commands;   // This module contains the logic for each specific command (lik
 mod utils;      // General utility functions that might be useful across different parts of the application.
 mod schema;     // Defines the structure of our configuration files (e.g., how a 'tool' or 'font' is described).
 mod logger;     // Handles setting up and managing our application's logging (debug, info, error messages).
-mod installers; // Contains the logic for installing various types of software (like GitHub tools, Homebrew packages, fonts).
+mod installers;
+
+use std::path::PathBuf;
+// Contains the logic for installing various types of software (like GitHub tools, Homebrew packages, fonts).
 // Import `colored` crate for adding color to terminal output, which enhances
 // the readability of log messages for the user.
 use colored::Colorize;
@@ -30,10 +33,11 @@ use commands::{generate, now, sync, version};
 // A brief description of what 'setup-devbox' does. This is shown in short help.
 #[command(about = "Setup development environment with ease", long_about = None)]
 struct Cli {
+    // Global argument for enabling debug logging.
     /// This argument allows users to turn on debugging information.
-    /// When they run `setup-devbox --debug` or `setup-devbox -d`,
-    /// our logger will show much more detailed messages, which is super helpful for troubleshooting!
-    #[arg(short, long, global = true)] // `-d` is short, `--debug` is long, `global = true` means it works for any subcommand.
+    // When they run `setup-devbox --debug` or `setup-devbox -d`,
+    // our logger will show much more detailed messages, which is super helpful for troubleshooting!
+    #[arg(short, long)]
     debug: bool,
 
     /// This is where we define the subcommands that 'setup-devbox' can execute.
@@ -46,44 +50,43 @@ struct Cli {
 /// Each variant here corresponds to an action the user can choose.
 #[derive(Subcommand)]
 enum Commands {
-    /// The 'version' subcommand:
-    /// When you type `setup-devbox version`, this tells you which version of the tool you're running.
+    // The 'version' subcommand:
+    /// Show the current Version of the tool.
     Version,
-    /// The 'now' subcommand:
-    /// This is probably the most exciting one! It tells `setup-devbox` to run the full setup process right away.
+    // The 'now' subcommand:
+    /// Installs and Configures Tools, Fonts, OS Settings and Shell Configs
     Now {
-        /// An optional argument to specify a custom path to the configuration file.
-        /// If not provided, 'setup-devbox' will look for a default config file.
+        /// Optional argument to specify the config files, else default is chosen.
         #[arg(long)] // This means the user would type `--config /path/to/my_config.yaml`
         config: Option<String>,
-        /// An optional argument to specify a custom path to the state file.
-        /// The state file keeps track of what 'setup-devbox' has already installed.
+        /// Optional argument to specify the state files, else default is chosen.
         #[arg(long)] // This means the user would type `--state /path/to/my_state.json`
         state: Option<String>,
     },
-    /// The 'generate' subcommand:
-    /// This command helps you get started by generating a sample configuration file.
-    /// It's super handy if you're new to 'setup-devbox'!
+    // The 'generate' subcommand:
+    /// Generates the default configs.
     Generate {
-        /// Just like with 'now', you can specify where to generate the new config file.
+        /// Optional argument to specify the config files, else default is chosen.
         #[arg(long)]
         config: Option<String>,
-        /// And where to potentially place a default state file alongside it.
+        /// Optional argument to specify the state files, else default is chosen.
         #[arg(long)]
         state: Option<String>,
     },
-    /// The 'sync' subcommand:
-    /// This command ensures that your installed tools and fonts match what's defined
-    /// in your configuration. It's great for keeping things up-to-date!
-    Sync {
-        /// You can tell 'sync' which state file to use for its operations.
+    // The 'sync-config' subcommand:
+    /// Sync or Generate configurations from state-file
+    SyncConfig {
+        /// Optional argument to specify the state files, (default: ~/.setup-devbox/state.json).
         #[arg(long)]
-        state: Option<String>,
+        state: Option<PathBuf>,
+        /// Optional argument to specify the config files, (default: ~/.setup-devbox/configs).
+        #[arg(long)]
+        output_dir: Option<PathBuf>,
     },
 }
 
-/// This is the main entry point of our entire application.
-/// When you run `setup-devbox` from your terminal, execution begins right here!
+// This is the main entry point of our entire application.
+// When you run `setup-devbox` from your terminal, execution begins right here!
 fn main() {
     // First things first, we parse the command-line arguments the user provided.
     // 'clap' takes care of all the heavy lifting, converting raw arguments into our `Cli` struct.
@@ -122,10 +125,14 @@ fn main() {
             generate::run(config, state); // ...we run the config generation process.
         }
         // If the user typed `setup-devbox sync`...
-        Commands::Sync { state } => {
-            log_debug!("[main] 'Sync' subcommand detected.");
-            log_debug!("[main] 'Sync' subcommand received state path: {:?}", state);
-            sync::run(state); // ...we initiate the state synchronization.
+        Commands::SyncConfig { state, output_dir } => { // Matched names to the struct fields
+            log_debug!("[main] 'SyncConfig' subcommand detected.");
+            // Create SyncConfigArgs from the parsed options
+            let args = sync::SyncConfigArgs {
+                state,      // Directly use the parsed Option<PathBuf>
+                output_dir, // Directly use the parsed Option<PathBuf>
+            };
+            sync::run(args); // Pass the SyncConfigArgs directly to sync::run
         }
     }
     log_debug!("[main] Command execution completed. Exiting application.");

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -172,7 +172,7 @@ pub struct SettingEntry {
 /// The complete structure of `state.json`, which acts as `setup-devbox`s memory.
 /// It records everything `setup-devbox` has done – what tools are installed, settings applied, etc.
 /// 'Clone' is derived here because we might need to easily duplicate this state object in memory.
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct DevBoxState {
     // A `HashMap` to keep track of all installed tools.
     // The key is likely the tool's name, and the value is its `ToolState` details.
@@ -202,6 +202,10 @@ pub struct ToolState {
     pub renamed_to: Option<String>,
     // The type of package (e.g., "binary", "go-module", "brew-formula").
     pub package_type: String,
+    // If the source is GitHub, this holds the repository in "owner/repo" format.
+    pub repo: Option<String>,
+    // If the source is GitHub, this holds the specific tag/release downloaded.
+    pub tag: Option<String>,
 }
 
 /// Records the state of a single system setting that `setup-devbox` has applied.
@@ -229,6 +233,10 @@ pub struct FontState {
     // A list of the actual font files (e.g., .ttf, .otf) that were installed for this font.
     pub files: Vec<String>,
     pub version: String,
+    #[serde(default)] // This ensures that if the field is missing in old state.json, it defaults to None
+    pub repo: Option<String>,
+    #[serde(default)] // Same for tag
+    pub tag: Option<String>,
 }
 
 //  Main Application Configuration


### PR DESCRIPTION
### Added `sync-config` command

- now configuration files can be generated based on state file
- command `setup-devbox sync-config` will generate the configuration files
- `sync-config` takes `--state` and `--output_dir` optionally
- default is `$HOME/.setup-devbox/configs` and `$HOME/.setup-devbox/state.json`

### Improvement in `State` Schema
- `FontState` and `ToolState` now has `repo` and `tag`
- This helps `sync-config` command to generate the configuration files