### PR TITLE
Installers implementation

### DIFF
--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -100,11 +100,12 @@ fn sync_state_to_configs(state_path: &PathBuf, output_dir: &PathBuf) {
     for (tool_name, tool_state) in devbox_state.tools {
         tools_entries.push(ToolEntry {
             name: tool_name, // Use the key from the HashMap as the tool's name
-            version: Some(tool_state.version), // `ToolState.version` maps to `ToolEntry.version`
-            source: tool_state.install_method, // `ToolState.install_method` maps to `ToolEntry.source`
-            repo: tool_state.repo,
-            tag: tool_state.tag,
-            rename_to: tool_state.renamed_to, // Maps directly
+            version: Some(tool_state.version),   // `ToolState.version` maps to `ToolEntry.version`
+            source: tool_state.install_method,   // `ToolState.install_method` maps to `ToolEntry.source`
+            repo: tool_state.repo,               // Repo Name
+            tag: tool_state.tag,                 // Git Tag usually
+            rename_to: tool_state.renamed_to,    // Maps directly
+            options: tool_state.options.clone(), // Pass the options if any
         });
     }
     let tool_config = ToolConfig { tools: tools_entries };

--- a/src/installers/brew.rs
+++ b/src/installers/brew.rs
@@ -124,5 +124,7 @@ pub fn install(tool: &ToolEntry) -> Option<ToolState> {
         // Not required for `Homebrew` installations
         // This is just placeholder for symmetry
         tag: Option::from("UNKNOWN_FROM_CONFIG".to_string()),
+        // Pass the options from ToolEntry to ToolState.
+        options: None,
     })
 }

--- a/src/installers/cargo.rs
+++ b/src/installers/cargo.rs
@@ -1,0 +1,125 @@
+// Imports necessary schema definitions for tools.
+use crate::schema::{ToolEntry, ToolState};
+// Imports custom logging macros.
+use crate::{log_debug, log_error, log_info, log_warn};
+// For adding color to terminal output.
+use colored::Colorize;
+// For executing external commands and capturing their output.
+use std::process::{Command, Output};
+// For working with file paths, specifically to construct installation paths.
+use std::path::PathBuf;
+
+/// Installs a Rust crate using `cargo install`.
+///
+/// This function constructs and executes the `cargo install` command.
+/// It handles versioning via `--version` and passes additional options
+/// like `--features` (if provided in `tool_entry.options`).
+///
+/// # Arguments
+/// * `tool_entry`: A reference to the `ToolEntry` struct containing details for the Rust crate.
+///
+/// # Returns
+/// An `Option<ToolState>`:
+/// * `Some(ToolState)` if the installation was successful, containing the installed state.
+/// * `None` if the installation failed or encountered an error.
+pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
+    log_debug!("[Cargo Installer] Attempting to install Cargo tool: {}", tool_entry.name.bold());
+
+    // Basic validation: Ensure 'cargo' command is available in the system's PATH.
+    if Command::new("cargo").arg("--version").output().is_err() {
+        log_error!(
+            "[Cargo Installer] 'cargo' command not found. Please ensure Rust/Cargo is installed and in your PATH."
+        );
+        return None;
+    }
+
+    // Initialize command arguments for `cargo install`. The tool name is always required.
+    let mut command_args = vec!["install", &tool_entry.name];
+
+    // Handle versioning if provided in the `ToolEntry`. Appends `--version <VERSION>` to the command.
+    if let Some(version) = &tool_entry.version {
+        command_args.push("--version");
+        command_args.push(version);
+    }
+
+    // Add any additional options specified in the `ToolEntry`, such as `--features`.
+    if let Some(options) = &tool_entry.options {
+        for opt in options {
+            command_args.push(opt);
+        }
+    }
+
+    log_info!("[Cargo Installer] Executing: {} {}", "cargo".cyan().bold(), command_args.join(" ").cyan());
+
+    // Execute the `cargo install` command and capture its output.
+    let output: Output = match Command::new("cargo")
+        .args(&command_args)
+        .output()
+    {
+        Ok(out) => out,
+        Err(e) => {
+            log_error!("[Cargo Installer] Failed to execute 'cargo install' command for '{}': {}", tool_entry.name.bold().red(), e);
+            return None;
+        }
+    };
+
+    // Check if the command executed successfully (exit code 0).
+    if output.status.success() {
+        log_info!(
+            "[Cargo Installer] Successfully installed Cargo tool: {}",
+            tool_entry.name.bold().green()
+        );
+        // Log standard output and error, as they might contain useful information or warnings.
+        if !output.stdout.is_empty() {
+            log_debug!("[Cargo Installer] Stdout: {}", String::from_utf8_lossy(&output.stdout));
+        }
+        if !output.stderr.is_empty() {
+            log_warn!("[Cargo Installer] Stderr (might contain warnings): {}", String::from_utf8_lossy(&output.stderr));
+        }
+
+        // Determine the installation path. Cargo typically installs binaries to `~/.cargo/bin/`.
+        let install_path = if let Ok(mut home) = std::env::var("HOME") {
+            home.push_str("/.cargo/bin/");
+            PathBuf::from(home).join(&tool_entry.name).to_string_lossy().into_owned()
+        } else {
+            // Fallback path if HOME environment variable is not set.
+            "/usr/local/bin/".to_string()
+        };
+
+        // Return a `ToolState` struct to record the successful installation.
+        Some(ToolState {
+            // Record actual version or "latest".
+            version: tool_entry.version.clone().unwrap_or_else(|| "latest".to_string()),
+            // The determined installation path.
+            install_path,
+            // Mark as installed by this application.
+            installed_by_devbox: true,
+            // Specify the installation method.
+            install_method: "cargo-install".to_string(),
+            // Record if the tool was renamed.
+            renamed_to: tool_entry.rename_to.clone(),
+            // Define the package type.
+            package_type: "rust-crate".to_string(),
+            // Not directly applicable for cargo installs from tool_entry.
+            repo: None,
+            // Not directly applicable for cargo installs from tool_entry.
+            tag: None,
+            // Pass the options from ToolEntry to ToolState.
+            options: tool_entry.options.clone(),
+        })
+    } else {
+        // Handle failed installation.
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        log_error!(
+            "[Cargo Installer] Failed to install Cargo tool '{}'. Exit code: {}. Error: {}",
+            tool_entry.name.bold().red(),
+            output.status.code().unwrap_or(-1),
+            stderr.red()
+        );
+        // Log stdout on failure for debugging.
+        if !output.stdout.is_empty() {
+            log_debug!("[Cargo Installer] Stdout (on failure): {}", String::from_utf8_lossy(&output.stdout));
+        }
+        None // Return None to indicate failure.
+    }
+}

--- a/src/installers/github.rs
+++ b/src/installers/github.rs
@@ -274,5 +274,7 @@ pub fn install(tool: &ToolEntry) -> Option<ToolState> {
         // for recording the most "truthful" type for diagnostics, even if we used
         // filename for extraction logic.
         package_type: actual_file_type_for_state,
+        // Pass the options from ToolEntry to ToolState.
+        options: None,
     })
 }

--- a/src/installers/go.rs
+++ b/src/installers/go.rs
@@ -1,0 +1,127 @@
+// Imports necessary schema definitions for tools.
+use crate::schema::{ToolEntry, ToolState};
+// Imports custom logging macros.
+use crate::{log_debug, log_error, log_info, log_warn};
+// For adding color to terminal output.
+use colored::Colorize;
+// For executing external commands and capturing their output.
+use std::process::{Command, Output};
+// For working with file paths, specifically to construct installation paths.
+use std::path::PathBuf;
+
+/// Installs a Go binary using `go install`.
+///
+/// This function constructs and executes the `go install` command.
+/// It intelligently handles versioning (if specified) using Go module syntax (`@version`)
+/// and passes additional options (e.g., build flags like `-ldflags`).
+///
+/// # Arguments
+/// * `tool_entry`: A reference to the `ToolEntry` struct containing details for the Go binary.
+///
+/// # Returns
+/// An `Option<ToolState>`:
+/// * `Some(ToolState)` if the installation was successful, containing the installed state.
+/// * `None` if the installation failed or encountered an error.
+pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
+    log_debug!("[Go Installer] Attempting to install Go tool: {}", tool_entry.name.bold());
+
+    // Basic validation: Ensure 'go' command is available in the system's PATH.
+    if Command::new("go").arg("version").output().is_err() {
+        log_error!(
+            "[Go Installer] 'go' command not found. Please ensure Go is installed and in your PATH."
+        );
+        return None;
+    }
+
+    // Initialize command arguments for `go install`.
+    let mut command_args = vec!["install"];
+
+    // Handle versioning if provided. Go modules typically use `@version` syntax.
+    let package_path = if let Some(version) = &tool_entry.version {
+        format!("{}@{}", tool_entry.name, version)
+    } else {
+        tool_entry.name.clone() // Install latest if no version specified.
+    };
+    command_args.push(&package_path);
+
+    // Add any additional options specified in the `ToolEntry`, e.g., build flags.
+    if let Some(options) = &tool_entry.options {
+        for opt in options {
+            command_args.push(opt);
+        }
+    }
+
+    log_info!("[Go Installer] Executing: {} {}", "go".cyan().bold(), command_args.join(" ").cyan());
+
+    // Execute the `go install` command and capture its output.
+    let output: Output = match Command::new("go")
+        .args(&command_args)
+        .output()
+    {
+        Ok(out) => out,
+        Err(e) => {
+            log_error!("[Go Installer] Failed to execute 'go install' command for '{}': {}", tool_entry.name.bold().red(), e);
+            return None;
+        }
+    };
+
+    // Check if the command executed successfully (exit code 0).
+    if output.status.success() {
+        log_info!(
+            "[Go Installer] Successfully installed Go tool: {}",
+            tool_entry.name.bold().green()
+        );
+        // Log standard output and error, as they might contain useful information or warnings.
+        if !output.stdout.is_empty() {
+            log_debug!("[Go Installer] Stdout: {}", String::from_utf8_lossy(&output.stdout));
+        }
+        if !output.stderr.is_empty() {
+            log_warn!("[Go Installer] Stderr (might contain warnings): {}", String::from_utf8_lossy(&output.stderr));
+        }
+
+        // Determine the installation path. Go typically installs binaries to GOPATH/bin or GOBIN.
+        // This is a common default for `go install`. A more robust solution might parse `go env GOBIN`.
+        let install_path = if let Ok(mut home) = std::env::var("HOME") {
+            home.push_str("/go/bin/"); // Common default for go install.
+            PathBuf::from(home).join(&tool_entry.name).to_string_lossy().into_owned()
+        } else {
+            "/usr/local/go/bin/".to_string() // Fallback path if HOME is not set.
+        };
+
+        // Return a `ToolState` struct to record the successful installation.
+        Some(ToolState {
+            // Record actual version or "latest".
+            version: tool_entry.version.clone().unwrap_or_else(|| "latest".to_string()),
+            // The determined installation path.
+            install_path,
+            // Mark as installed by this application.
+            installed_by_devbox: true,
+            // Specify the installation method.
+            install_method: "go-install".to_string(),
+            // Record if the tool was renamed.
+            renamed_to: tool_entry.rename_to.clone(),
+            // Define the package type.
+            package_type: "go-module".to_string(),
+            // Not directly applicable for Go module installs from tool_entry.
+            repo: None,
+            // Not directly applicable for Go module installs from tool_entry.
+            tag: None,
+            // Pass the options from ToolEntry to ToolState.
+            options: tool_entry.options.clone(),
+        })
+    } else {
+        // Handle failed installation.
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        log_error!(
+            "[Go Installer] Failed to install Go tool '{}'. Exit code: {}. Error: {}",
+            tool_entry.name.bold().red(),
+            output.status.code().unwrap_or(-1),
+            stderr.red()
+        );
+        // Log stdout on failure for debugging.
+        if !output.stdout.is_empty() {
+            log_debug!("[Go Installer] Stdout (on failure): {}", String::from_utf8_lossy(&output.stdout));
+        }
+        None // Return None to indicate failure.
+    }
+}

--- a/src/installers/mod.rs
+++ b/src/installers/mod.rs
@@ -5,3 +5,4 @@ pub(crate) mod cargo;
 pub(crate) mod fonts;
 pub(crate) mod shellrc;
 pub(crate) mod rustup;
+pub(crate) mod pip;

--- a/src/installers/mod.rs
+++ b/src/installers/mod.rs
@@ -4,3 +4,4 @@ pub(crate) mod go;
 pub(crate) mod cargo;
 pub(crate) mod fonts;
 pub(crate) mod shellrc;
+pub(crate) mod rustup;

--- a/src/installers/pip.rs
+++ b/src/installers/pip.rs
@@ -1,0 +1,126 @@
+// Imports necessary schema definitions for tools.
+use crate::schema::{ToolEntry, ToolState};
+// Imports custom logging macros.
+use crate::{log_debug, log_error, log_info, log_warn};
+// For adding color to terminal output.
+use colored::Colorize;
+// For executing external commands and capturing their output.
+use std::process::{Command, Output};
+// For working with file paths, specifically to construct installation paths.
+use std::path::PathBuf;
+
+/// Installs a Python package using `pip`.
+///
+/// This function constructs and executes the `pip install` command.
+/// It handles package names, optional versions (e.g., `package==1.2.3`),
+/// and additional pip options (e.g., `--user`, `--index-url`) passed via `tool_entry.options`.
+///
+/// # Arguments
+/// * `tool_entry`: A reference to the `ToolEntry` struct containing details for the Python package.
+///                 `tool_entry.name` is the package name (e.g., "requests", "black").
+///                 `tool_entry.version` is the optional version specifier (e.g., "1.2.3").
+///                 `tool_entry.options` can contain a list of additional pip arguments.
+///
+/// # Returns
+/// An `Option<ToolState>`:
+/// * `Some(ToolState)` if the installation was successful.
+/// * `None` if the installation failed.
+pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
+    log_debug!("[Pip Installer] Attempting to install Python package: {}", tool_entry.name.bold());
+
+    // 1. Basic validation: Ensure 'pip' command is available.
+    // We try to find 'pip3' first, as it's often the preferred modern Python 3 pip.
+    // If not found, fall back to 'pip'.
+    let pip_command = if Command::new("pip3").arg("--version").output().is_ok() {
+        "pip3"
+    } else if Command::new("pip").arg("--version").output().is_ok() {
+        "pip"
+    } else {
+        log_error!(
+            "[Pip Installer] 'pip' or 'pip3' command not found. Please ensure Python and Pip are installed and in your PATH."
+        );
+        return None;
+    };
+
+    let mut command_args = vec!["install"];
+
+    // Construct the package name with an optional version specifier.
+    let package_specifier = if let Some(version) = &tool_entry.version {
+        format!("{}=={}", tool_entry.name, version)
+    } else {
+        tool_entry.name.clone()
+    };
+    command_args.push(&package_specifier);
+
+    // Add any additional options specified in the `ToolEntry` (e.g., --user, --upgrade).
+    if let Some(options) = &tool_entry.options {
+        for opt in options {
+            command_args.push(opt);
+        }
+    }
+
+    log_info!("[Pip Installer] Executing: {} {}", pip_command.cyan().bold(), command_args.join(" ").cyan());
+
+    // Execute the `pip install` command.
+    let output: Output = match Command::new(pip_command)
+        .args(&command_args)
+        .output()
+    {
+        Ok(out) => out,
+        Err(e) => {
+            log_error!("[Pip Installer] Failed to execute '{} install' command for '{}': {}", pip_command.bold().red(), tool_entry.name.bold().red(), e);
+            return None;
+        }
+    };
+
+    if output.status.success() {
+        log_info!(
+            "[Pip Installer] Successfully installed Python package: {}",
+            tool_entry.name.bold().green()
+        );
+        if !output.stdout.is_empty() {
+            log_debug!("[Pip Installer] Stdout: {}", String::from_utf8_lossy(&output.stdout));
+        }
+        if !output.stderr.is_empty() {
+            log_warn!("[Pip Installer] Stderr (might contain warnings): {}", String::from_utf8_lossy(&output.stderr));
+        }
+
+        // Determining the exact install_path for pip packages can be complex (site-packages, user-base, venvs).
+        // For simplicity, we'll indicate a common user-level path or a generic Python bin path.
+        // A more robust solution might parse `pip show <package>` output for 'Location' or 'Installed-Location'.
+        let install_path = if let Ok(mut home) = std::env::var("HOME") {
+            // This is a common location for user-installed packages, but not always the executable path.
+            // For executables installed by pip (e.g., `black`), they might be in ~/.local/bin
+            home.push_str("/.local/bin/"); // Common location for scripts installed by pip --user
+            PathBuf::from(home).join(&tool_entry.name).to_string_lossy().into_owned()
+        } else {
+            // Generic fallback, actual binary might be elsewhere
+            "/usr/local/bin/".to_string()
+        };
+
+
+        Some(ToolState {
+            version: tool_entry.version.clone().unwrap_or_else(|| "latest".to_string()),
+            install_path,
+            installed_by_devbox: true,
+            install_method: "pip".to_string(),
+            renamed_to: tool_entry.rename_to.clone(),
+            package_type: "python-package".to_string(),
+            repo: None, // Pip packages don't typically map directly to GitHub repos in ToolEntry.
+            tag: None,  // Pip packages don't typically map directly to a tag in ToolEntry.
+            options: tool_entry.options.clone(), // Store the additional options used.
+        })
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        log_error!(
+            "[Pip Installer] Failed to install Python package '{}'. Exit code: {}. Error: {}",
+            tool_entry.name.bold().red(),
+            output.status.code().unwrap_or(-1),
+            stderr.red()
+        );
+        if !output.stdout.is_empty() {
+            log_debug!("[Pip Installer] Stdout (on failure): {}", String::from_utf8_lossy(&output.stdout));
+        }
+        None
+    }
+}

--- a/src/installers/rustup.rs
+++ b/src/installers/rustup.rs
@@ -1,10 +1,12 @@
-// src/installers/rustup.rs
-// This module provides functionality to install Rust toolchains and components using `rustup`.
-
+// Imports necessary schema definitions for tools.
 use crate::schema::{ToolEntry, ToolState};
+// Imports custom logging macros.
 use crate::{log_debug, log_error, log_info, log_warn};
+// For adding color to terminal output.
 use colored::Colorize;
+// For executing external commands and capturing their output.
 use std::process::{Command, Output};
+// For working with file paths, specifically to construct installation paths.
 use std::path::PathBuf;
 
 /// Installs a Rust toolchain and optionally components using `rustup`.

--- a/src/installers/rustup.rs
+++ b/src/installers/rustup.rs
@@ -1,0 +1,166 @@
+// src/installers/rustup.rs
+// This module provides functionality to install Rust toolchains and components using `rustup`.
+
+use crate::schema::{ToolEntry, ToolState};
+use crate::{log_debug, log_error, log_info, log_warn};
+use colored::Colorize;
+use std::process::{Command, Output};
+use std::path::PathBuf;
+
+/// Installs a Rust toolchain and optionally components using `rustup`.
+///
+/// This function first ensures `rustup` is available. It then constructs and
+/// executes `rustup toolchain install` using the `tool_entry.version` as the
+/// toolchain name (e.g., "stable", "nightly", "1.70.0").
+/// If `tool_entry.options` are provided, they are treated as `rustup component add`
+/// arguments for the newly installed toolchain.
+///
+/// # Arguments
+/// * `tool_entry`: A reference to the `ToolEntry` struct containing details for the Rust toolchain.
+///                 `tool_entry.name` is expected to be "rust" or "rustup".
+///                 `tool_entry.version` is the toolchain name (e.g., "stable", "nightly").
+///                 `tool_entry.options` can contain a list of components to add (e.g., "rust-src", "rust-docs").
+///
+/// # Returns
+/// An `Option<ToolState>`:
+/// * `Some(ToolState)` if the installation (toolchain + components) was successful.
+/// * `None` if any part of the installation failed.
+pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
+    log_debug!("[Rustup Installer] Attempting to install Rust toolchain: {}", tool_entry.name.bold());
+
+    // 1. Basic validation: Ensure 'rustup' command is available.
+    if Command::new("rustup").arg("--version").output().is_err() {
+        log_error!(
+            "[Rustup Installer] 'rustup' command not found. Please ensure Rustup is installed and in your PATH."
+        );
+        return None;
+    }
+
+    // Determine the toolchain to install.
+    // We expect the 'version' field in ToolEntry to specify the toolchain (e.g., "stable", "nightly").
+    let toolchain_name = match &tool_entry.version {
+        Some(v) => v.clone(),
+        None => {
+            log_error!(
+                "[Rustup Installer] Toolchain version (e.g., 'stable', 'nightly', '1.70.0') is required for rustup tool '{}'.",
+                tool_entry.name.bold().red()
+            );
+            return None;
+        }
+    };
+
+    // 2. Install the Rust toolchain.
+    let toolchain_command_args = vec!["toolchain", "install", &toolchain_name];
+
+    log_info!("[Rustup Installer] Executing: {} {}", "rustup".cyan().bold(), toolchain_command_args.join(" ").cyan());
+
+    let output_toolchain: Output = match Command::new("rustup")
+        .args(&toolchain_command_args)
+        .output()
+    {
+        Ok(out) => out,
+        Err(e) => {
+            log_error!("[Rustup Installer] Failed to execute 'rustup toolchain install' for '{}': {}", toolchain_name.bold().red(), e);
+            return None;
+        }
+    };
+
+    if !output_toolchain.status.success() {
+        let stderr = String::from_utf8_lossy(&output_toolchain.stderr);
+        log_error!(
+            "[Rustup Installer] Failed to install toolchain '{}'. Exit code: {}. Error: {}",
+            toolchain_name.bold().red(),
+            output_toolchain.status.code().unwrap_or(-1),
+            stderr.red()
+        );
+        if !output_toolchain.stdout.is_empty() {
+            log_debug!("[Rustup Installer] Stdout (on failure): {}", String::from_utf8_lossy(&output_toolchain.stdout));
+        }
+        return None;
+    } else {
+        log_info!(
+            "[Rustup Installer] Successfully installed toolchain: {}",
+            toolchain_name.bold().green()
+        );
+        if !output_toolchain.stdout.is_empty() {
+            log_debug!("[Rustup Installer] Stdout: {}", String::from_utf8_lossy(&output_toolchain.stdout));
+        }
+        if !output_toolchain.stderr.is_empty() {
+            log_warn!("[Rustup Installer] Stderr (might contain warnings): {}", String::from_utf8_lossy(&output_toolchain.stderr));
+        }
+    }
+
+    // 3. Install components if specified in options.
+    if let Some(components) = &tool_entry.options {
+        for component in components {
+            let component_command_args = vec!["component", "add", component, "--toolchain", &toolchain_name];
+
+            log_info!("[Rustup Installer] Executing: {} {}", "rustup".cyan().bold(), component_command_args.join(" ").cyan());
+
+            let output_component: Output = match Command::new("rustup")
+                .args(&component_command_args)
+                .output()
+            {
+                Ok(out) => out,
+                Err(e) => {
+                    log_error!(
+                        "[Rustup Installer] Failed to execute 'rustup component add' for '{}' on toolchain '{}': {}",
+                        component.bold().red(),
+                        toolchain_name.bold().red(),
+                        e
+                    );
+                    return None; // Fail if any component fails
+                }
+            };
+
+            if !output_component.status.success() {
+                let stderr = String::from_utf8_lossy(&output_component.stderr);
+                log_error!(
+                    "[Rustup Installer] Failed to add component '{}' to toolchain '{}'. Exit code: {}. Error: {}",
+                    component.bold().red(),
+                    toolchain_name.bold().red(),
+                    output_component.status.code().unwrap_or(-1),
+                    stderr.red()
+                );
+                if !output_component.stdout.is_empty() {
+                    log_debug!("[Rustup Installer] Stdout (on failure): {}", String::from_utf8_lossy(&output_component.stdout));
+                }
+                return None; // Fail if any component fails
+            } else {
+                log_info!(
+                    "[Rustup Installer] Successfully added component '{}' to toolchain '{}'.",
+                    component.bold().green(),
+                    toolchain_name.bold().green()
+                );
+                if !output_component.stdout.is_empty() {
+                    log_debug!("[Rustup Installer] Stdout: {}", String::from_utf8_lossy(&output_component.stdout));
+                }
+                if !output_component.stderr.is_empty() {
+                    log_warn!("[Rustup Installer] Stderr (might contain warnings): {}", String::from_utf8_lossy(&output_component.stderr));
+                }
+            }
+        }
+    }
+
+    // Determine the installation path. Rustup manages its own paths, often in ~/.rustup/toolchains/<toolchain_name>
+    let install_path = if let Ok(mut home) = std::env::var("HOME") {
+        home.push_str(&format!("/.rustup/toolchains/{}/bin", toolchain_name));
+        PathBuf::from(home).to_string_lossy().into_owned()
+    } else {
+        // A generic fallback, though less accurate for rustup
+        "/usr/local/bin/".to_string()
+    };
+
+    // Return a ToolState indicating successful installation.
+    Some(ToolState {
+        version: toolchain_name,
+        install_path,
+        installed_by_devbox: true,
+        install_method: "rustup".to_string(),
+        renamed_to: tool_entry.rename_to.clone(), // Renaming not typical for rustup, but kept for schema consistency.
+        package_type: "rust-toolchain".to_string(),
+        repo: None, // Not directly from a single repo.
+        tag: None,  // Not directly from a single tag.
+        options: tool_entry.options.clone(), // Store the components that were added.
+    })
+}

--- a/src/libs/tool_installer.rs
+++ b/src/libs/tool_installer.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use colored::Colorize;
 // Imports custom logging macros.
 use crate::{log_debug, log_error, log_info, log_warn};
-use crate::installers::{brew, cargo, github, go, rustup};
+use crate::installers::{brew, cargo, github, go, pip, rustup};
 // Imports schema definitions for application state and tool configurations.
 use crate::schema::{DevBoxState, ToolConfig};
 // Imports the function for saving the application state.
@@ -49,6 +49,7 @@ pub fn install_tools(tools_cfg: ToolConfig, state: &mut DevBoxState, state_path_
                 "go" => go::install(tool),         // Call Go installer for "go" source.
                 "cargo" => cargo::install(tool),   // Call Cargo installer for "cargo" source.
                 "rustup" => rustup::install(tool), // Call Rustup installer for "rustup" source.
+                "pip" => pip::install(tool),       // Call PIP installer for "python" source.
                 other => {
                     // Log a warning if the source is not supported and skip the tool.
                     log_warn!(

--- a/src/libs/tool_installer.rs
+++ b/src/libs/tool_installer.rs
@@ -1,40 +1,60 @@
+// For working with file paths, particularly for the state file.
 use std::path::PathBuf;
+// For adding color to terminal output, enhancing readability.
 use colored::Colorize;
+// Imports custom logging macros.
 use crate::{log_debug, log_error, log_info, log_warn};
-use crate::installers::{brew, github};
+use crate::installers::{
+    brew,    // Imports the Homebrew installer module.
+    cargo,   // Imports the Cargo (Rust) installer module.
+    github,  // Imports the GitHub release installer module.
+    go,      // Imports the Go installer module.
+};
+// Imports schema definitions for application state and tool configurations.
 use crate::schema::{DevBoxState, ToolConfig};
+// Imports the function for saving the application state.
 use crate::libs::state_management::save_devbox_state;
 
 /// Installs tools based on the provided configuration and updates the application state.
 ///
-/// This function iterates through each tool defined in `tools_cfg`, checks if it's
-/// already installed according to `state`, and delegates to the appropriate installer
-/// (brew, github) for new or updated tools. It also handles state persistence.
+/// This function iterates through each tool defined in `tools_cfg`,
+/// checks if it's already installed according to `state`,
+/// and delegates to the appropriate installer (brew, GitHub, go, cargo) for new or updated tools.
+/// It also handles state persistence by saving changes to `state.json`.
 ///
 /// # Arguments
 /// * `tools_cfg`: A `ToolConfig` struct containing the list of tools to install.
 /// * `state`: A mutable reference to the `DevBoxState` to update installed tools.
 /// * `state_path_resolved`: The `PathBuf` to the `state.json` file for saving.
 pub fn install_tools(tools_cfg: ToolConfig, state: &mut DevBoxState, state_path_resolved: &PathBuf) {
+    // Add a newline for better visual separation in the terminal.
     eprintln!("\n");
-    log_info!("[Tools] Processing Tools Installations...");
-    log_debug!("Entering install_tools() function.");
+    log_info!("[Tools] Processing Tools Installations..."); // Informative log message.
+    log_debug!("Entering install_tools() function."); // Debug log for function entry.
 
+    // Flag to track if any tools were installed or updated.
     let mut tools_updated = false;
+    // List to store names of skipped tools.
     let mut skipped_tools: Vec<String> = Vec::new();
 
+    // Iterate through each tool entry defined in the `tools.yaml` configuration.
     for tool in &tools_cfg.tools {
         log_debug!("[Tools] Considering tool: {:?}", tool.name.bold());
+        // Check if the tool is already recorded in the current `DevBoxState`.
         if !state.tools.contains_key(&tool.name) {
-            print!("\n");
-            eprintln!("{}", "==============================================================================================".bright_blue());
-            log_info!("[Tools] Installing new tool from {}: {}", tool.source.to_string().bright_yellow(), tool.name.to_string().bright_blue().bold());
-            log_debug!("[Tools] Full configuration details for tool '{}': {:?}", tool.name, tool);
+            print!("\n"); // Add newline for visual clarity before installing a new tool.
+            eprintln!("{}", "==============================================================================================".bright_blue()); // Visual separator.
+            log_info!("[Tools] Installing new tool from {}: {}", tool.source.to_string().bright_yellow(), tool.name.to_string().bright_blue().bold()); // Informative log for new installation.
+            log_debug!("[Tools] Full configuration details for tool '{}': {:?}", tool.name, tool); // Debug log of the tool's full config.
 
+            // Dispatch the installation to the appropriate installer function based on the tool's source.
             let installation_result = match tool.source.as_str() {
-                "github" => github::install(tool),
-                "brew" => brew::install(tool),
+                "github" => github::install(tool), // Call GitHub installer for "GitHub" source.
+                "brew" => brew::install(tool),     // Call Homebrew installer for "brew" source.
+                "go" => go::install(tool),         // Call Go installer for "go" source.
+                "cargo" => cargo::install(tool),   // Call Cargo installer for "cargo" source.
                 other => {
+                    // Log a warning if the source is not supported and skip the tool.
                     log_warn!(
                         "[Tools] Unsupported source '{}' for tool '{}'. Skipping this tool's installation.",
                         other.yellow(),
@@ -44,24 +64,28 @@ pub fn install_tools(tools_cfg: ToolConfig, state: &mut DevBoxState, state_path_
                 }
             };
 
+            // If installation was successful, update the `DevBoxState` and set the `tools_updated` flag.
             if let Some(tool_state) = installation_result {
-                state.tools.insert(tool.name.clone(), tool_state);
-                tools_updated = true;
-                log_info!("[Tools] {}: {}", "Successfully installed tool".yellow() ,tool.name.bold().bright_green());
-                eprintln!("{}", "==============================================================================================".blue());
-                print!("\n");
+                state.tools.insert(tool.name.clone(), tool_state); // Add the newly installed tool's state to the map.
+                tools_updated = true; // Mark that changes occurred.
+                log_info!("[Tools] {}: {}", "Successfully installed tool".yellow() ,tool.name.bold().bright_green()); // Success message.
+                eprintln!("{}", "==============================================================================================".blue()); // Visual separator.
+                print!("\n"); // Add newline.
             } else {
+                // Log an error if installation failed.
                 log_error!(
                     "[Tools] Failed to install tool: {}. Please review previous logs for specific errors during installation.",
                     tool.name.bold().red()
                 );
             }
         } else {
+            // If the tool is already installed, add it to the skipped list.
             skipped_tools.push(tool.name.clone());
             log_debug!("[Tools] Tool '{}' is already recorded as installed. Added to skipped list.", tool.name.blue());
         }
     }
 
+    // Report on any tools that were skipped because they were already installed.
     if !skipped_tools.is_empty() {
         let skipped_tools_str = skipped_tools.join(", ");
         log_info!(
@@ -72,15 +96,16 @@ pub fn install_tools(tools_cfg: ToolConfig, state: &mut DevBoxState, state_path_
         log_debug!("[Tools] No tools were skipped as they were not found in the state.");
     }
 
+    // If any tools were installed or updated, save the `DevBoxState` to `state.json`.
     if tools_updated {
         log_info!("[Tools] New tools installed or state updated. Saving current DevBox state...");
-        if !save_devbox_state(state, state_path_resolved) {
+        if !save_devbox_state(state, state_path_resolved) { // Call utility to save state.
             log_error!("[StateSave] Failed to save state after tool installations. Data loss risk!");
         }
         log_info!("[StateSave] State saved successfully after tool updates.");
     } else {
         log_info!("[Tools] No new tools installed or state changes detected for tools.");
     }
-    eprintln!();
-    log_debug!("Exiting install_tools() function.");
+    eprintln!(); // Final newline for consistent output spacing.
+    log_debug!("Exiting install_tools() function."); // Debug log for function exit.
 }

--- a/src/libs/tool_installer.rs
+++ b/src/libs/tool_installer.rs
@@ -4,12 +4,7 @@ use std::path::PathBuf;
 use colored::Colorize;
 // Imports custom logging macros.
 use crate::{log_debug, log_error, log_info, log_warn};
-use crate::installers::{
-    brew,    // Imports the Homebrew installer module.
-    cargo,   // Imports the Cargo (Rust) installer module.
-    github,  // Imports the GitHub release installer module.
-    go,      // Imports the Go installer module.
-};
+use crate::installers::{brew, cargo, github, go, rustup};
 // Imports schema definitions for application state and tool configurations.
 use crate::schema::{DevBoxState, ToolConfig};
 // Imports the function for saving the application state.
@@ -53,6 +48,7 @@ pub fn install_tools(tools_cfg: ToolConfig, state: &mut DevBoxState, state_path_
                 "brew" => brew::install(tool),     // Call Homebrew installer for "brew" source.
                 "go" => go::install(tool),         // Call Go installer for "go" source.
                 "cargo" => cargo::install(tool),   // Call Cargo installer for "cargo" source.
+                "rustup" => rustup::install(tool), // Call Rustup installer for "rustup" source.
                 other => {
                     // Log a warning if the source is not supported and skip the tool.
                     log_warn!(

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -76,6 +76,12 @@ pub struct ToolEntry {
     // If the downloaded executable has a generic name (e.g., "cli") but the user
     // wants it to be called something specific (e.g., "mycli"), this field allows renaming.
     pub rename_to: Option<String>,
+    // Additional options or flags to pass directly to the installer command.
+    // For "go", build flags like `-ldflags`. For "cargo", features like `--features`.
+    // `#[serde(default)]` ensures that if this field is missing in the YAML, it defaults to `None`
+    // instead of causing a deserialization error.
+    #[serde(default)]
+    pub options: Option<Vec<String>>,
 }
 
 /// Configuration schema for `shellac.yaml`.
@@ -206,6 +212,10 @@ pub struct ToolState {
     pub repo: Option<String>,
     // If the source is GitHub, this holds the specific tag/release downloaded.
     pub tag: Option<String>,
+    // Additional options or flags that were passed to the installer command during installation.
+    // This helps in re-installing with the same options if needed, or for debugging.
+    #[serde(default)] // Important: This allows the field to be optional in YAML without errors
+    pub options: Option<Vec<String>>,
 }
 
 /// Records the state of a single system setting that `setup-devbox` has applied.


### PR DESCRIPTION
### Add more installers

- `Go` installer
- `Cargo` installer
- `Rustup` installer
- `Pip` installer

### Example of `tools.yaml`

```
# ~/.setup-devbox/configs/tools.yaml

# This file defines the software tools that setup-devbox will manage and install.
# Each item in the 'tools' list represents a single tool to be installed.

tools:
  # --- GitHub Release Installer Example (source: github) ---
  # Ideal for tools distributed as pre-compiled binaries via GitHub Releases.
  - name: terraform             # The name of the tool (e.g., 'terraform', 'kubectl')
    source: github              # Specifies that the tool should be downloaded from GitHub Releases.
    repo: hashicorp/terraform   # REQUIRED for 'github' source: The GitHub repository in 'owner/repo' format.
    version: 1.8.5              # (Optional) The specific version to download. If omitted,
                                # will attempt to find the latest stable release.
    # tag: v1.8.5               # (Optional) A specific release tag to look for if `version` isn't
                                # enough or the tag format differs (e.g., "v1.8.5").
    rename_to: tf               # (Optional) Rename the downloaded executable (e.g., 'terraform' to 'tf').
    # options:                  # (Optional) Not typically used for direct GitHub binary downloads,
                                # as there are no "install options" in this context.

  # --- Go Installer Example (source: go) ---
  # For installing Go binaries directly from their source code via `go install`.
  - name: github.com/cli/cli/v2/cmd/gh # The Go module path for the tool.
    source: go                  # Specifies the Go installer.
    version: v2.50.0            # (Optional) The version to install (e.g., "v2.50.0", "latest").
                                # This is appended as `@version` to the module path.
    rename_to: gh               # (Optional) Rename the resulting executable (e.g., 'gh' from 'cmd/gh').
    options:                    # (Optional) Additional build flags for `go install`.
      - -ldflags="-s -w"        # Example: Strips debug info and DWARF tables for smaller binaries.
      # - -tags=some_feature    # Example: Build with specific Go build tags.

  # --- Rustup Installer Example (source: rustup) ---
  # For managing Rust toolchains and components using `rustup`.
  - name: rust                  # A generic name, as `rustup` manages the toolchain itself.
                                # You could also use "rustup-toolchain".
    source: rustup              # Specifies the Rustup installer.
    version: stable             # REQUIRED: The Rust toolchain to install (e.g., "stable", "nightly", "1.70.0").
    options:                    # (Optional) A list of components to add to the installed toolchain.
      - rust-src                # Example: Install source code for the Rust standard library.
      - rust-docs               # Example: Install offline documentation.
      - clippy                  # Example: Install the Clippy linter.
      - rustfmt                 # Example: Install the Rust code formatter.
    # rename_to:                # Not typically applicable for rustup, as it manages system-wide toolchains.

  # --- Cargo Installer Example (source: cargo) ---
  # For installing Rust crates published on crates.io via `cargo install`.
  - name: cargo-watch           # The name of the Rust crate (e.g., 'cargo-watch', 'cargo-audit').
    source: cargo               # Specifies the Cargo installer.
    version: 8.5.1              # (Optional) The specific version of the crate to install.
                                # If omitted, cargo will install the latest.
    options:                    # (Optional) Additional flags for `cargo install`.
      - --features="notify"     # Example: Enable specific features for the crate.
      # - --locked              # Example: Use `Cargo.lock` if present.
    # rename_to:                # (Optional) Rename the installed binary.

  # --- Pip Installer Example (source: pip) ---
  # For installing Python packages from PyPI (or other sources) using `pip`.
  - name: black                 # The name of the Python package (e.g., 'black', 'requests', 'ansible').
    source: pip                 # Specifies the Pip installer.
    version: 24.4.2             # (Optional) The specific version of the package (e.g., '24.4.2').
                                # If omitted, pip will install the latest.
    options:                    # (Optional) Additional arguments to pass to `pip install`.
      - --user                  # IMPORTANT: Installs package to user's home directory to avoid
                                #          system Python conflicts. Highly recommended.
      - --upgrade               # Example: Always upgrade to the specified version if already installed.
      # - --index-url=https://pypi.example.com/simple/ # Example: Specify a custom PyPI mirror.
    # rename_to:                # (Optional) Rename the installed script (e.g., 'black' to 'myblack').

  # --- Homebrew Installer Example (source: brew) ---
  # For installing macOS/Linux packages using Homebrew (brew install).
  - name: git                   # The formula name (e.g., 'git', 'node', 'jq').
    source: brew                # Specifies the Homebrew installer.
    # version:                  # (Optional) Homebrew usually handles versions through taps/formulae.
                                # If you need a specific older version, you'd typically
                                # use a versioned formula or `brew install <formula>@<version>`.
                                # The `brew` installer doesn't currently use this `version` field.
    options:                    # (Optional) Additional flags for `brew install`.
      - --without-completion    # Example: Skip shell completion scripts for `git`.
      # - --HEAD                # Example: Install the latest commit from master (for some formulae).
    # rename_to:                # Not typically applicable for Homebrew packages, as they install
                                # to standard Homebrew paths.
```