### PR TITLE
Filter fonts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,16 +70,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "base64ct"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "bitflags"
@@ -97,20 +100,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
+name = "bumpalo"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
-name = "bzip2"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
-dependencies = [
- "bzip2-sys",
- "libc",
-]
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bzip2"
@@ -119,16 +112,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bea8dcd42434048e4f7a304411d9273a411f647446c1234a65ce0554923f4cff"
 dependencies = [
  "libbz2-rs-sys",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.13+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
-dependencies = [
- "cc",
- "pkg-config",
 ]
 
 [[package]]
@@ -215,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "constant_time_eq"
-version = "0.1.5"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "cpufeatures"
@@ -238,12 +221,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,12 +231,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "deflate64"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b"
+
+[[package]]
 name = "deranged"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -340,6 +334,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
 dependencies = [
  "crc32fast",
+ "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -567,6 +562,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
+name = "liblzma"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0791ab7e08ccc8e0ce893f6906eb2703ed8739d8e89b57c0714e71bad09024c8"
+dependencies = [
+ "liblzma-sys",
+]
+
+[[package]]
+name = "liblzma-sys"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01b9596486f6d60c3bbe644c0e1be1aa6ccc472ad630fe8927b456973d7cb736"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,6 +590,15 @@ dependencies = [
  "bitflags",
  "libc",
  "redox_syscall",
+]
+
+[[package]]
+name = "libz-rs-sys"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "172a788537a2221661b480fee8dc5f96c580eb34fa88764d3205dc356c7e4221"
+dependencies = [
+ "zlib-rs",
 ]
 
 [[package]]
@@ -635,26 +659,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
-name = "password-hash"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
-dependencies = [
- "base64ct",
- "rand_core",
- "subtle",
-]
-
-[[package]]
 name = "pbkdf2"
-version = "0.11.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest",
  "hmac",
- "password-hash",
- "sha2",
 ]
 
 [[package]]
@@ -685,6 +696,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppmd-rust"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c834641d8ad1b348c9ee86dec3b9840d805acd5f24daa5f90c788951a52ff59b"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,12 +724,6 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "redox_syscall"
@@ -869,7 +880,7 @@ dependencies = [
 name = "setup-devbox"
 version = "0.1.0"
 dependencies = [
- "bzip2 0.6.0",
+ "bzip2",
  "clap",
  "colored",
  "dirs",
@@ -896,21 +907,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "smallvec"
@@ -1343,6 +1349,20 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"
@@ -1379,40 +1399,64 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.6.6"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+checksum = "9aed4ac33e8eb078c89e6cbb1d5c4c7703ec6d299fc3e7c3695af8f8b423468b"
 dependencies = [
  "aes",
- "byteorder",
- "bzip2 0.4.4",
+ "arbitrary",
+ "bzip2",
  "constant_time_eq",
  "crc32fast",
- "crossbeam-utils",
+ "deflate64",
  "flate2",
+ "getrandom 0.3.3",
  "hmac",
+ "indexmap",
+ "liblzma",
+ "memchr",
  "pbkdf2",
+ "ppmd-rust",
  "sha1",
  "time",
+ "zeroize",
+ "zopfli",
  "zstd",
 ]
 
 [[package]]
-name = "zstd"
-version = "0.11.2+zstd.1.5.2"
+name = "zlib-rs"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+checksum = "626bd9fa9734751fc50d6060752170984d7053f5a39061f524cda68023d4db8a"
+
+[[package]]
+name = "zopfli"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfc5ee405f504cd4984ecc6f14d02d55cfda60fa4b689434ef4102aae150cd7"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
+version = "7.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
 dependencies = [
- "libc",
  "zstd-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ tar = "0.4.44"
 
 # 'zip' is a library for working with `.zip` archives.
 # Zip files are another popular format for bundling and compressing files, especially common on Windows.
-zip = "0.6.0"
+zip = "4.3.0"
 
 # 'bzip2' provides bindings to the `bzip2` compression library.
 # This crate allows your application to handle `.bz2` compressed files and `.tar.bz2` archives.

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -9,7 +9,6 @@ use crate::{
 use crate::libs::state_management::read_devbox_state;
 use clap::Args;
 use colored::Colorize;
-use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -89,7 +88,6 @@ fn sync_state_to_configs(state_path: &PathBuf, output_dir: &PathBuf) {
 
     // Prepare vectors/maps to hold the converted config structs
     let mut tools_entries: Vec<ToolEntry> = Vec::new();
-    let mut settings_entries_by_os: HashMap<String, Vec<SettingEntry>> = HashMap::new();
     let mut fonts_entries: Vec<FontEntry> = Vec::new();
 
     // 3. Convert ToolState entries to ToolEntry

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -151,6 +151,8 @@ fn sync_state_to_configs(state_path: &PathBuf, output_dir: &PathBuf) {
             source: source_type,
             repo: font_state.repo,
             tag: font_state.tag,
+            // Todo: Fix below
+            install_only: None,
         });
     }
     let font_config = FontConfig { fonts: fonts_entries };

--- a/src/installers/fonts.rs
+++ b/src/installers/fonts.rs
@@ -27,21 +27,276 @@ use crate::schema::FontState;
 // and extracting archives, which are reused across various installer modules.
 use crate::utils;
 
+/// Helper struct to return validated font entry details.
+struct ValidatedFontDetails<'a> {
+    repo: &'a str,
+    tag: &'a str,
+    asset_name: String,
+    url: String,
+}
+
+/// Validates the font entry's source and required GitHub fields.
+///
+/// # Arguments
+/// * `font`: A reference to the `FontEntry` struct.
+///
+/// # Returns
+/// * `Result<ValidatedFontDetails, String>`:
+///   - `Ok(ValidatedFontDetails)` if validation passes, containing extracted repo, tag, asset name, and URL.
+///   - `Err(String)` if validation fails, with an error message.
+fn validate_font_entry(font: &FontEntry) -> Result<ValidatedFontDetails, String> {
+    log_debug!("[Font:Validation] Starting validation for font: {}", font.name.bold());
+
+    // Validate Font Source
+    if font.source != "github" {
+        return Err(format!(
+            "Installation failed for '{}': Unsupported font source '{}'. Only 'github' is currently supported.",
+            font.name.red(),
+            font.source.red()
+        ));
+    }
+    log_debug!("[Font:Validation] Font source 'github' is validated.");
+
+    // Validate Required GitHub Fields (Repository and Tag)
+    let repo = font.repo.as_ref().ok_or_else(|| {
+        format!(
+            "Installation failed for '{}': Missing 'repo' field in font configuration. This is required for GitHub sources.",
+            font.name.red()
+        )
+    })?;
+    log_debug!("[Font:Validation] GitHub repository specified: {}", repo.blue());
+
+    let tag = font.tag.as_ref().ok_or_else(|| {
+        format!(
+            "Installation failed for '{}': Missing 'tag' field in font configuration. This is required for GitHub sources.",
+            font.name.red()
+        )
+    })?;
+    log_debug!("[Font:Validation] GitHub release tag specified: {}", tag.blue());
+
+    // Construct Download URL
+    let asset_name = format!("{}.zip", font.name.replace(' ', ""));
+    let url = format!("https://github.com/{}/releases/download/{}/{}", repo, tag, asset_name);
+    log_debug!("[Font:Validation] Constructed download URL: {}", url.blue());
+
+    Ok(ValidatedFontDetails {
+        repo,
+        tag,
+        asset_name,
+        url,
+    })
+}
+
+/// Downloads the font archive to a temporary directory.
+///
+/// # Arguments
+/// * `font_name`: The name of the font.
+/// * `url`: The URL to download the archive from.
+/// * `asset_name`: The expected filename of the downloaded asset.
+///
+/// # Returns
+/// * `Result<PathBuf, String>`:
+///   - `Ok(PathBuf)` if download is successful, containing the path to the downloaded archive.
+///   - `Err(String)` if download fails.
+fn download_font_archive(font_name: &str, url: &str, asset_name: &str) -> Result<PathBuf, String> {
+    log_info!("[Font:Download] Attempting to download font archive for '{}' from URL: {}", font_name.bold(), url.blue());
+
+    let temp_dir = utils::get_temp_dir();
+    let archive_path = temp_dir.join(asset_name);
+    log_debug!("[Font:Download] Temporary download path for font archive: {:?}", archive_path.display().to_string().yellow());
+
+    if let Err(err) = utils::download_file(url, &archive_path) {
+        let _ = fs::remove_file(&archive_path); // Clean up partial download
+        return Err(format!(
+            "Download failed for font '{}' from {}: {}. Please check URL or network connection.",
+            font_name.red(),
+            url.red(),
+            err
+        ));
+    }
+    log_info!("[Font:Download] Font archive downloaded successfully to {}", archive_path.display().to_string().green());
+    Ok(archive_path)
+}
+
+/// Extracts the contents of the font archive.
+///
+/// # Arguments
+/// * `font_name`: The name of the font.
+/// * `archive_path`: The path to the downloaded archive.
+/// * `temp_dir`: The base temporary directory.
+///
+/// # Returns
+/// * `Result<PathBuf, String>`:
+///   - `Ok(PathBuf)` if extraction is successful, containing the path to the extracted directory.
+///   - `Err(String)` if extraction fails.
+fn extract_font_archive(font_name: &str, archive_path: &PathBuf, temp_dir: &PathBuf) -> Result<PathBuf, String> {
+    log_debug!("[Font:Extract] Detecting file type from filename for extraction.");
+    let file_type_from_name = utils::detect_file_type_from_filename(&archive_path.to_string_lossy());
+    log_debug!("[Font:Extract] Detected downloaded file type (from filename): {}", file_type_from_name.magenta());
+
+    let extracted_dir = match utils::extract_archive(archive_path, temp_dir, Some(&file_type_from_name)) {
+        Ok(path) => path,
+        Err(err) => {
+            let _ = fs::remove_file(archive_path); // Clean up the original archive
+            return Err(format!(
+                "Failed to extract archive {:?} for font '{}': {}. Archive might be corrupted or in an unsupported format.",
+                archive_path.display().to_string().red(),
+                font_name.red(),
+                err
+            ));
+        }
+    };
+    log_info!("[Font:Extract] Font archive extracted to: {}", extracted_dir.display().to_string().green());
+    let _ = fs::remove_file(archive_path); // Clean up the original downloaded archive
+    Ok(extracted_dir)
+}
+
+/// Determines and creates the macOS Fonts directory.
+///
+/// # Returns
+/// * `Result<PathBuf, String>`:
+///   - `Ok(PathBuf)` if the fonts directory is successfully determined and created.
+///   - `Err(String)` if the directory cannot be determined or created.
+fn get_font_installation_dir(font_name: &str) -> Result<PathBuf, String> {
+    let fonts_dir = dirs::home_dir()
+        .map(|path| path.join("Library/Fonts"))
+        .or_else(|| {
+            env::var("HOME")
+                .ok()
+                .map(|home| PathBuf::from(home).join("Library/Fonts"))
+        })
+        .ok_or_else(|| {
+            format!(
+                "Could not determine the user's Home directory or standard Fonts directory. Cannot install font '{}'.",
+                font_name.red()
+            )
+        })?;
+
+    if let Err(err) = fs::create_dir_all(&fonts_dir) {
+        return Err(format!(
+            "Failed to create target fonts directory {:?}: {}. This directory is required for installation.",
+            fonts_dir.display().to_string().red(),
+            err
+        ));
+    }
+    log_debug!("[Font:TargetDir] Target fonts directory for installation set to: {:?}", fonts_dir.display().to_string().blue());
+    Ok(fonts_dir)
+}
+
+/// Copies font files from the extracted directory to the target font directory,
+/// applying the `install_only` filter.
+///
+/// # Arguments
+/// * `font_name`: The name of the font.
+/// * `extracted_dir`: The path to the directory where font files were extracted.
+/// * `fonts_dir`: The target system fonts directory.
+/// * `install_only_keywords`: Optional list of keywords for filtering filenames.
+///
+/// # Returns
+/// * `Result<Vec<String>, String>`:
+///   - `Ok(Vec<String>)` if files are successfully copied, containing their paths.
+///   - `Err(String)` if reading the extracted directory fails.
+fn copy_font_files(
+    font_name: &str,
+    extracted_dir: &PathBuf,
+    fonts_dir: &PathBuf,
+    install_only_keywords: &Option<Vec<String>>,
+) -> Result<Vec<String>, String> {
+    let mut installed_font_files: Vec<String> = Vec::new();
+
+    let read_dir_result = fs::read_dir(extracted_dir).map_err(|e| {
+        format!(
+            "Failed to read extracted directory {:?}. It might be empty or corrupted. Error: {}",
+            extracted_dir.display().to_string().yellow(),
+            e
+        )
+    })?;
+
+    // Prepare filter keywords if present
+    let filter_keywords: Option<Vec<String>> = install_only_keywords.as_ref().map(|keywords| {
+        keywords.iter().map(|k| k.to_lowercase()).collect()
+    });
+
+    if let Some(keywords) = &filter_keywords {
+        if keywords.is_empty() {
+            log_info!("[Font:Copy] 'install_only' field is empty for '{}'. All detected font files will be considered for installation.", font_name.blue());
+        } else {
+            log_info!("[Font:Copy] Applying 'install_only' filter for '{}' with keywords: {:?}", font_name.blue(), keywords);
+        }
+    } else {
+        log_info!("[Font:Copy] No 'install_only' filter specified for '{}'. All detected font files will be considered for installation.", font_name.blue());
+    }
+
+    for entry in read_dir_result {
+        let entry = entry.map_err(|e| format!("Skipping invalid directory entry: {}", e))?;
+        let path = entry.path();
+        log_debug!("[Font:Copy] Examining extracted path: {:?}", path.display().to_string().dimmed());
+
+        if path.is_file() {
+            if let Some(ext) = path.extension() {
+                let ext_str = ext.to_string_lossy().to_lowercase();
+
+                if ext_str == "ttf" || ext_str == "otf" {
+                    let file_name = path.file_name()
+                        .and_then(|name| name.to_str())
+                        .ok_or_else(|| format!("Skipping font file with no valid filename detected: {:?}", path.display()))?
+                        .to_string();
+
+                    let file_name_lower = file_name.to_lowercase();
+
+                    let should_install = if let Some(keywords) = &filter_keywords {
+                        keywords.is_empty() || keywords.iter().any(|keyword| file_name_lower.contains(keyword))
+                    } else {
+                        true
+                    };
+
+                    if should_install {
+                        let target_path = fonts_dir.join(&file_name);
+                        log_debug!("[Font:Copy] Attempting to copy font file from {:?} to {:?}", path.display().to_string().yellow(), target_path.display().to_string().yellow());
+
+                        if let Err(err) = fs::copy(&path, &target_path) {
+                            log_warn!(
+                                "[Font:Copy] Failed to copy font file {:?} to {:?}: {}",
+                                path.display().to_string().yellow(),
+                                target_path.display().to_string().yellow(),
+                                err
+                            );
+                        } else {
+                            log_debug!("[Font:Copy] Successfully copied font file: {:?}", target_path.display().to_string().green());
+                            installed_font_files.push(target_path.display().to_string());
+                        }
+                    } else {
+                        log_debug!("[Font:Copy] Skipping font file '{}' (does not match 'install_only' filter).", file_name.dimmed());
+                    }
+                } else {
+                    log_debug!("[Font:Copy] Skipping non-font file based on extension: {:?} (extension: {})", path.display().to_string().dimmed(), ext_str.dimmed());
+                }
+            } else {
+                log_debug!("[Font:Copy] Skipping file with no detected extension: {:?}", path.display().to_string().dimmed());
+            }
+        } else if path.is_dir() {
+            log_debug!("[Font:Copy] Skipping directory entry: {:?}", path.display().to_string().dimmed());
+        }
+    }
+    Ok(installed_font_files)
+}
+
+/// Cleans up the temporary directory.
+///
+/// # Arguments
+/// * `temp_dir`: The path to the temporary directory to remove.
+fn cleanup_temp_dir(temp_dir: &PathBuf) {
+    if let Err(err) = fs::remove_dir_all(temp_dir) {
+        log_warn!("[Font:Cleanup] Failed to clean up temporary directory {:?}: {}", temp_dir.display().to_string().yellow(), err);
+    } else {
+        log_debug!("[Font:Cleanup] Temporary directory {:?} successfully cleaned up.", temp_dir.display());
+    }
+}
+
 /// Installs a font from a GitHub release as specified by the `FontEntry`.
 ///
-/// This function performs the following steps:
-/// 1. Validates that the font's source is "GitHub".
-/// 2. Extracts necessary repository and tag information from the `FontEntry`.
-/// 3. Constructs the precise download URL for the font archive.
-/// 4. Downloads the font archive to a temporary directory.
-/// 5. Extracts the contents of the archive.
-/// 6. Identifies the standard macOS font installation directory (~/Library/Fonts).
-/// 7. Iterates through the extracted files, identifying and copying actual font files (.ttf, .otf).
-/// 8. Applies an `install_only` filter to copy only specific font files
-///    whose names contain the specified keywords (case-insensitive).
-/// 9. Cleans up temporary files and directories.
-/// 10. Returns a `FontState` object upon successful installation, providing details
-///    about the installed font, or `None` if any critical step fails.
+/// This function orchestrates the entire font installation workflow by calling
+/// several private helper functions.
 ///
 /// # Arguments
 /// * `font`: A reference to a `FontEntry` struct that holds all the configuration
@@ -50,289 +305,74 @@ use crate::utils;
 /// # Returns
 /// * `Option<FontState>`:
 ///   - `Some(FontState)` if the installation process was successful and at least one
-///     valid font file was copied to the system. The `FontState` contains details
-///     like the font's name, version, download URL, and a list of installed files.
+///     valid font file was copied to the system.
 ///   - `None` if the installation failed at any point, or if no font files were
 ///     found/copied from the downloaded archive.
 pub fn install(font: &FontEntry) -> Option<FontState> {
     log_info!("Initiating font installation for: {}", font.name.bold());
     log_debug!("[Font] Detailed font entry configuration received: {:?}", font);
 
-    // 1. Validate Font Source
-    // The current implementation is designed only for fonts sourced from GitHub.
-    // If the 'source' field in the FontEntry is not "github", we log an error
-    // and terminate the installation attempt for this font.
-    if font.source != "github" {
-        log_error!(
-            "[Font] Installation failed for '{}': Unsupported font source '{}'. Only 'github' is currently supported.",
-            font.name.red(),
-            font.source.red()
-        );
-        return None;
-    }
-    log_debug!("[Font] Font source 'github' is validated and supported, proceeding with installation workflow.");
-
-    // 2. Validate Required GitHub Fields (Repository and Tag)
-    // For GitHub-sourced fonts, both the 'repo' (repository owner/name) and 'tag'
-    // (release tag, e.g., 'v1.0.0') fields are absolutely essential to locate the release.
-
-    // Attempt to extract the repository string from the FontEntry.
-    let repo = match &font.repo {
-        Some(r) => r, // If present, use the reference to the repository string.
-        None => {
-            // If 'repo' is missing, log an error and return None.
-            log_error!(
-                "[Font] Installation failed for '{}': Missing 'repo' field in font configuration. This is required for GitHub sources.",
-                font.name.red()
-            );
+    // 1. Validate Font Entry
+    let validated_details = match validate_font_entry(font) {
+        Ok(details) => details,
+        Err(e) => {
+            log_error!("[Font] {}. Aborting installation.", e);
             return None;
         }
     };
-    log_debug!("[Font] GitHub repository specified for font '{}': {}", font.name, repo.blue());
+    let url = validated_details.url;
+    let asset_name = validated_details.asset_name;
+    let repo = validated_details.repo;
+    let tag = validated_details.tag;
 
-    // Attempt to extract the release tag string from the FontEntry.
-    let tag = match &font.tag {
-        Some(t) => t, // If present, use the reference to the tag string.
-        None => {
-            // If 'tag' is missing, log an error and return None.
-            log_error!(
-                "[Font] Installation failed for '{}': Missing 'tag' field in font configuration. This is required for GitHub sources.",
-                font.name.red()
-            );
-            return None;
-        }
-    };
-    log_debug!("[Font] GitHub release tag specified for font '{}': {}", font.name, tag.blue());
-
-    // 3. Construct Download URL
-    // GitHub release assets often follow a common naming convention,
-    // typically including the repository, release tag, and an asset filename.
-    // We construct the expected asset filename by replacing spaces in the font name
-    // (as filenames usually don't contain spaces) and appending the tag and ".zip".
-    let asset_name = format!("{}.zip", font.name.replace(' ', "")); // Most fonts are distributed as ZIPs
-    // Combine the repository, tag, and asset name into a full GitHub release download URL.
-    let url = format!("https://github.com/{}/releases/download/{}/{}", repo, tag, asset_name);
-    log_info!("[Font] Attempting to download font archive for '{}' from URL: {}", font.name.bold(), url.blue());
-    log_debug!("[Font] Expected GitHub asset filename: {}", asset_name.cyan());
-
-    // --- 4. Download the Font Archive ---
-    // First, obtain a path to a temporary directory where we can safely download
-    // and extract files without interfering with other system locations.
+    // Get a dedicated temporary directory for this installation process
     let temp_dir = utils::get_temp_dir();
-    // Construct the full path where the downloaded ZIP archive will be saved within the temporary directory.
-    let archive_path = temp_dir.join(&asset_name);
-    log_debug!("[Font] Temporary download path for font archive: {:?}", archive_path.display().to_string().yellow());
+    let temp_dir_clone_for_cleanup = temp_dir.clone(); // Clone for eventual cleanup in defer
 
-    // Use the `utils::download_file` function to perform the actual download.
-    // This function handles the network request and saving the file.
-    if let Err(err) = utils::download_file(&url, &archive_path) {
-        log_error!(
-            "[Font] Download failed for font '{}' from {}: {}. Please check URL or network connection.",
-            font.name.red(),
-            url.red(),
-            err
-        );
-        // Attempt to clean up any partially downloaded archive file to free space.
-        let _ = fs::remove_file(&archive_path);
-        // Return None as the download failed, indicating installation cannot proceed.
-        return None;
-    }
-    log_info!("[Font] Font archive downloaded successfully to {}", archive_path.display().to_string().green());
+    // Use `defer!` if available, otherwise ensure cleanup with `_drop` or similar patterns.
+    // For simplicity, we'll manually call cleanup_temp_dir at the end or on error.
 
-    // 5. Extract the Font Archive
-    // Detect the file type based on the filename, which is more reliable for archives
-    // from known sources like GitHub releases.
-    let file_type_from_name = utils::detect_file_type_from_filename(&archive_path.to_string_lossy());
-    log_debug!("[Font] Detected downloaded file type (from filename): {}", file_type_from_name.magenta());
-
-
-    // Extract the contents of the downloaded ZIP archive into another specific
-    // subdirectory within the temporary directory. This keeps extracted files organized.
-    let extracted_dir = match utils::extract_archive(&archive_path, &temp_dir, Some(&file_type_from_name)) {
-        Ok(path) => path, // If extraction is successful, `path` is the directory where contents were placed.
-        Err(err) => {
-            // If extraction fails, log the error.
-            log_error!(
-                "[Font] Failed to extract archive {:?} for font '{}': {}. Archive might be corrupted or in an unsupported format.",
-                archive_path.display().to_string().red(),
-                font.name.red(),
-                err
-            );
-            // Attempt to clean up the original downloaded archive and the entire temporary directory.
-            let _ = fs::remove_file(&archive_path);
-            let _ = fs::remove_dir_all(&temp_dir);
-            return None; // Return None as extraction failed.
-        }
-    };
-    log_info!("[Font] Font archive extracted to: {}", extracted_dir.display().to_string().green());
-    // After successful extraction, the original downloaded archive is no longer needed.
-    // Attempt to remove it to free up disk space.
-    let _ = fs::remove_file(&archive_path);
-
-    // 6. Determine macOS Fonts Directory
-    // On macOS, user-specific fonts are conventionally installed in the
-    // `~/Library/Fonts` directory. We need to derive this path reliably.
-
-    // Use `dirs::home_dir()` from the `dirs` crate (a cross-platform way to get common directories)
-    // to get the user's home directory.
-    let fonts_dir = dirs::home_dir()
-        // If `dirs::home_dir()` succeeds, append "Library/Fonts" to it.
-        .map(|path| path.join("Library/Fonts"))
-        // If `dirs::home_dir()` fails (unlikely on macOS), fallback to checking the `HOME`
-        // environment variable, which is a common convention.
-        .or_else(|| {
-            env::var("HOME")
-                .ok() // Convert `Result` to `Option` for chaining.
-                .map(|home| PathBuf::from(home).join("Library/Fonts"))
-        });
-
-    let fonts_dir = match fonts_dir {
-        Some(path) => path, // If a valid fonts directory path was determined, use it.
-        None => {
-            // If no fonts directory could be determined by any method, log an error.
-            log_error!(
-                "[Font] Could not determine the user's Home directory or standard Fonts directory. Cannot install font '{}'.",
-                font.name.red()
-            );
-            let _ = fs::remove_dir_all(&temp_dir); // Clean up the temporary directory.
-            return None; // Return None as the target path is unknown.
+    // 2. Download the Font Archive
+    let archive_path = match download_font_archive(&font.name, &url, &asset_name) {
+        Ok(path) => path,
+        Err(e) => {
+            log_error!("[Font] {}. Aborting installation.", e);
+            cleanup_temp_dir(&temp_dir_clone_for_cleanup);
+            return None;
         }
     };
 
-    // Ensure that the target fonts directory actually exists on the filesystem.
-    // If it doesn't, create all necessary parent directories.
-    if let Err(err) = fs::create_dir_all(&fonts_dir) {
-        log_error!(
-            "[Font] Failed to create target fonts directory {:?}: {}. This directory is required for installation.",
-            fonts_dir.display().to_string().red(),
-            err
-        );
-        let _ = fs::remove_dir_all(&temp_dir); // Clean up the temporary directory.
-        return None; // Return None as we cannot install without the target directory.
-    }
-    log_debug!("[Font] Target fonts directory for installation set to: {:?}", fonts_dir.display().to_string().blue());
-
-    // 7. Copy Font Files to Fonts Directory
-    // Initialize a vector to store the paths of all successfully installed font files.
-    // This list will be part of the `FontState` if the installation is successful.
-    let mut installed_font_files: Vec<String> = Vec::new();
-
-    // Attempt to read the contents of the extracted directory.
-    let read_dir_result = fs::read_dir(&extracted_dir);
-    if read_dir_result.is_err() {
-        // If reading the directory fails, it means we can't find any font files.
-        log_warn!(
-            "[Font] Failed to read extracted directory {:?}. It might be empty or corrupted. Error: {}",
-            extracted_dir.display().to_string().yellow(),
-            read_dir_result.unwrap_err() // Safely unwrap the error for logging.
-        );
-        let _ = fs::remove_dir_all(&temp_dir); // Clean up the temporary directory.
-        // Return None because no font files could be processed.
-        return None;
-    }
-
-    // Determine if an `install_only` filter is present and not empty.
-    // Convert keywords to lowercase once to optimize comparisons.
-    let filter_keywords: Option<Vec<String>> = font.install_only.as_ref().map(|keywords| {
-        keywords.iter().map(|k| k.to_lowercase()).collect()
-    });
-
-    if let Some(keywords) = &filter_keywords {
-        if keywords.is_empty() {
-            log_info!("[Font] 'install_only' field is empty for '{}'. All detected font files will be considered for installation.", font.name.blue());
-        } else {
-            log_info!("[Font] Applying 'install_only' filter for '{}' with keywords: {:?}", font.name.blue(), keywords);
+    // 3. Extract the Font Archive
+    let extracted_dir = match extract_font_archive(&font.name, &archive_path, &temp_dir) {
+        Ok(path) => path,
+        Err(e) => {
+            log_error!("[Font] {}. Aborting installation.", e);
+            cleanup_temp_dir(&temp_dir_clone_for_cleanup);
+            return None;
         }
-    } else {
-        log_info!("[Font] No 'install_only' filter specified for '{}'. All detected font files will be considered for installation.", font.name.blue());
-    }
+    };
 
-    // Iterate through each entry (file or subdirectory) found within the extracted archive's directory.
-    for entry in read_dir_result.unwrap() {
-        // Safely unwrap each directory entry. If an entry is invalid, skip it with a warning.
-        let entry = match entry {
-            Ok(e) => e,
-            Err(e) => {
-                log_warn!(
-                    "[Font] Skipping invalid directory entry encountered while processing extracted fonts: {}",
-                    e
-                );
-                continue; // Move to the next entry.
-            }
-        };
-
-        let path = entry.path(); // Get the full path of the current entry.
-        log_debug!("[Font] Examining extracted path: {:?}", path.display().to_string().dimmed());
-
-        // Check if the current path points to a regular file. We are only interested in files.
-        if path.is_file() {
-            // Attempt to get the file extension.
-            if let Some(ext) = path.extension() {
-                // Convert the extension to a lowercase string for case-insensitive comparison.
-                let ext_str = ext.display().to_string().to_lowercase();
-
-                // Check if the file extension is a common font file type (.ttf or .otf).
-                if ext_str == "ttf" || ext_str == "otf" {
-                    let file_name = match path.file_name() {
-                        Some(name) => name.to_string_lossy().to_string(), // Get filename as String
-                        None => {
-                            log_warn!("[Font] Skipping font file with no valid filename detected: {:?}", path.display().to_string().yellow());
-                            continue;
-                        }
-                    };
-                    let file_name_lower = file_name.to_lowercase();
-
-                    // Apply the `install_only` filter
-                    let should_install = if let Some(keywords) = &filter_keywords {
-                        // If `install_only` is specified and not empty, check if any keyword matches.
-                        // If keywords are empty, it means no specific filter, so all fonts are allowed.
-                        keywords.is_empty() || keywords.iter().any(|keyword| {
-                            file_name_lower.contains(keyword)
-                        })
-                    } else {
-                        // If `install_only` is not specified in FontEntry, install all font files.
-                        true
-                    };
-
-                    if should_install {
-                        // Construct the full target path in the user's Fonts directory.
-                        let target_path = fonts_dir.join(&file_name); // Use the original filename
-                        log_debug!("[Font] Attempting to copy font file from {:?} to {:?}", path.display().to_string().yellow(), target_path.display().to_string().yellow());
-
-                        // Perform the file copy operation.
-                        if let Err(err) = fs::copy(&path, &target_path) {
-                            // If copying fails for a specific font file, log a warning but continue
-                            // processing other files, as one failed copy shouldn't halt the whole process.
-                            log_warn!(
-                                "[Font] Failed to copy font file {:?} to {:?}: {}",
-                                path.display().to_string().yellow(),
-                                target_path.display().to_string().yellow(),
-                                err
-                            );
-                        } else {
-                            // If the copy is successful, log a debug message and add the target path
-                            // to our list of successfully installed font files.
-                            log_debug!("[Font] Successfully copied font file: {:?}", target_path.display().to_string().green());
-                            installed_font_files.push(target_path.display().to_string());
-                        }
-                    } else {
-                        log_debug!("[Font] Skipping font file '{}' (does not match 'install_only' filter).", file_name.dimmed());
-                    }
-                } else {
-                    log_debug!("[Font] Skipping non-font file based on extension: {:?} (extension: {})", path.display().to_string().dimmed(), ext_str.dimmed());
-                }
-            } else {
-                log_debug!("[Font] Skipping file with no detected extension: {:?}", path.display().to_string().dimmed());
-            }
-        } else if path.is_dir() {
-            log_debug!("[Font] Skipping directory entry: {:?}", path.display().to_string().dimmed());
-            // This implementation does not recursively search subdirectories for fonts.
-            // All font files are expected to be directly within the extracted root.
+    // 4. Determine macOS Fonts Directory
+    let fonts_dir = match get_font_installation_dir(&font.name) {
+        Ok(path) => path,
+        Err(e) => {
+            log_error!("[Font] {}. Aborting installation.", e);
+            cleanup_temp_dir(&temp_dir_clone_for_cleanup);
+            return None;
         }
-    }
+    };
 
-    // 8. Final Status and Cleanup
-    // Provide a summary of the font installation attempt.
+    // 5. Copy Font Files to Fonts Directory (with install_only filter)
+    let installed_font_files = match copy_font_files(&font.name, &extracted_dir, &fonts_dir, &font.install_only) {
+        Ok(files) => files,
+        Err(e) => {
+            log_error!("[Font] {}. Aborting installation.", e);
+            cleanup_temp_dir(&temp_dir_clone_for_cleanup);
+            return None;
+        }
+    };
+
+    // 6. Final Status and Cleanup
     if !installed_font_files.is_empty() {
         log_info!(
             "[Font] Installation of font '{}' completed. Successfully copied {} font files.",
@@ -340,7 +380,6 @@ pub fn install(font: &FontEntry) -> Option<FontState> {
             installed_font_files.len().to_string().cyan()
         );
     } else {
-        // If no font files were found or successfully copied, issue a warning.
         log_warn!(
             "[Font] No .ttf or .otf font files were found or successfully copied from the archive for '{}'. \
              The font might not be correctly installed, the archive format is unexpected, or no files matched the 'install_only' filter.",
@@ -348,37 +387,20 @@ pub fn install(font: &FontEntry) -> Option<FontState> {
         );
     }
 
-    // Clean up the temporary directory and all its contents (downloaded archive, extracted files).
-    // Errors during cleanup are generally not critical to the main installation outcome.
-    if let Err(err) = fs::remove_dir_all(&temp_dir) {
-        log_warn!("[Font] Failed to clean up temporary directory {:?}: {}", temp_dir.display().to_string().yellow(), err);
-    } else {
-        log_debug!("[Font] Temporary directory {:?} successfully cleaned up.", temp_dir.display());
-    }
+    cleanup_temp_dir(&temp_dir_clone_for_cleanup);
 
-    // 9. Return FontState for Tracking (Conditional)
-    // A `FontState` object is returned only if at least one font file was successfully copied.
-    // This ensures that the state file accurately reflects truly installed fonts.
+    // 7. Return FontState for Tracking (Conditional)
     if !installed_font_files.is_empty() {
         log_debug!("[Font] Constructing FontState for '{}'.", font.name.bold());
         Some(FontState {
             name: font.name.clone(),
-            // Prioritize the `version` field from `FontEntry`. If not present, fall back to the `tag`.
-            // If neither is present (should be caught by earlier validation for 'tag'), use "unknown".
             version: font.version.clone().unwrap_or_else(|| font.tag.clone().unwrap_or_else(|| "unknown".to_string())),
-            // Store the exact URL from which the font archive was downloaded.
             url,
-            // Record the repository name
-            // Helps in `sync` command
             repo: font.repo.clone(),
-            // Record the tag name
-            // Helps in `sync` command
             tag: font.tag.clone(),
-            files: installed_font_files, // Store the list of absolute paths to the installed font files.
+            files: installed_font_files,
         })
     } else {
-        // If no font files were successfully installed (even if the archive was downloaded/extracted),
-        // return `None` to indicate that the font is not considered "installed" by devbox's tracking.
         log_debug!("[Font] No font files were installed for '{}', so no FontState will be recorded.", font.name.bold());
         None
     }

--- a/src/libs/font_installer.rs
+++ b/src/libs/font_installer.rs
@@ -1,9 +1,21 @@
+// src/libs/font_installer.rs
+
 use std::path::PathBuf;
 use colored::Colorize;
+// Adjust the import path for logging macros if they are not directly in `crate::` but, for example, in `crate::utils::logging`.
+// Assuming they are still at the top-level crate import for now.
 use crate::{log_debug, log_error, log_info};
-use crate::installers::fonts;
+
+// The path to the font installer module will change because it's now under `installers`.
+// It was already `crate::installers::fonts;` so this line remains the same as `font_installer.rs` calls it.
+use crate::installers::fonts; // This import is correct for the new structure
+
 use crate::schema::{DevBoxState, FontConfig};
+// If `state_management` is also in `src/libs/`, its path would be `crate::libs::state_management::save_devbox_state;`
+// For now, assuming it's `crate::libs::state_management::save_devbox_state` or a top-level `crate::state_management`.
+// Based on your original file, it's `crate::libs::state_management::save_devbox_state`, so it remains the same.
 use crate::libs::state_management::save_devbox_state;
+
 
 /// Installs fonts based on the provided configuration and updates the application state.
 ///
@@ -27,16 +39,12 @@ pub fn install_fonts(fonts_cfg: FontConfig, state: &mut DevBoxState, state_path_
         if !state.fonts.contains_key(&font.name) {
             print!("\n");
             eprintln!("{}", "==============================================================================================".bright_blue());
-            log_info!("[Fonts] Installing new font: {}", font.name.bold());
-            log_debug!("[Fonts] Full configuration details for font '{}': {:?}", font.name, font);
-
-            let installation_result = fonts::install(font);
-
-            if let Some(font_state) = installation_result {
-                state.fonts.insert(font.name.clone(), font_state);
+            log_info!("[Fonts] Installing {}...", font.name.bold().cyan());
+            if let Some(font_state) = fonts::install(font) {
+                state.fonts.insert(font_state.name.clone(), font_state);
                 fonts_updated = true;
-                log_info!("[Fonts] Successfully installed font: {}", font.name.bold().green());
-                eprintln!("{}", "==============================================================================================".bright_blue());
+                log_info!("[Fonts] Successfully installed {}.", font.name.bold().green());
+                eprintln!("{}", "===============================================================================================".bright_blue());
                 print!("\n");
             } else {
                 log_error!(

--- a/src/libs/settings_applier.rs
+++ b/src/libs/settings_applier.rs
@@ -1,12 +1,12 @@
 // src/libs/settings_applier.rs
 
-use std::process::Command;
-use std::path::PathBuf;
-use colored::Colorize;
-use crate::{log_debug, log_error, log_info, log_warn};
-// Make sure to import SettingEntry here (since it's used as the config entry type)
-use crate::schema::{DevBoxState, SettingsConfig, SettingEntry, SettingState};
 use crate::libs::state_management::save_devbox_state;
+// Make sure to import SettingEntry here (since it's used as the config entry type)
+use crate::schema::{DevBoxState, SettingState, SettingsConfig};
+use crate::{log_debug, log_error, log_info, log_warn};
+use colored::Colorize;
+use std::path::PathBuf;
+use std::process::Command;
 
 /// Applies system settings based on the provided configuration and updates the application state.
 // ... (documentation remains the same) ...

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -139,6 +139,12 @@ pub struct FontEntry {
     pub repo: Option<String>,
     // A specific tag or release on GitHub to download the font from.
     pub tag: Option<String>,
+    // If 'install_only' is not in YAML, it defaults to None
+    #[serde(default)]
+    // When serializing, skip if None
+    #[serde(skip_serializing_if = "Option::is_none")]
+    // Optional list of keywords for filtering
+    pub install_only: Option<Vec<String>>,
 }
 
 /// Configuration schema for `settings.yaml`.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -14,7 +14,7 @@ use colored::Colorize;
 // For decompressing gzipped archives (like .tar.gz files).
 // `flate2` is a widely used Rust library for handling various compression formats,
 // and `GzDecoder` specifically deals with gzip decompression.
-use flate2::read::GzDecoder;
+pub(crate) use flate2::read::GzDecoder;
 // To get environment variables, like the temporary directory or home directory.
 // `std::env` provides functions to interact with the process's environment.
 // `std::io` contains core input/output functionalities and error types.
@@ -34,7 +34,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 // For extracting tar archives.
 // The `tar` crate provides functionality to read and write tar archives.
-use tar::Archive;
+pub(crate) use tar::Archive;
 // For extracting zip archives.
 // The `zip` crate provides functionality to read and write zip archives.
 use zip::ZipArchive;


### PR DESCRIPTION
### Filter Fonts

- now `install_only` key can be used to filter what fonts needs to be installed

### Example
```
fonts:
- name: 0xProto
  version: 3.4.0
  source: github
  repo: ryanoasis/nerd-fonts
  tag: v3.4.0
  install_only: ['regular', 'Mono']
```