### PR TITLE
Additional command

### DIFF
--- a/src/commands/version.rs
+++ b/src/commands/version.rs
@@ -19,22 +19,6 @@ use ureq;
 const REPO_OWNER: &str = "kodelint"; // The GitHub username or organization that owns the repository.
 const REPO_NAME: &str = "setup-devbox"; // The name of the repository to check for releases.
 
-/// Represents the top-level structure of a `Cargo.toml` file relevant to this module.
-/// This struct is used by Serde to deserialize the TOML content.
-#[derive(Deserialize)]
-struct CargoToml {
-    // The `package` field directly maps to the `[package]` section in `Cargo.toml`.
-    package: Package,
-}
-
-/// Represents the `[package]` section within `Cargo.toml`.
-/// Specifically designed to extract the `version` field.
-#[derive(Deserialize)]
-struct Package {
-    // The `version` field holds the package's version string, e.g., "0.1.0".
-    version: String,
-}
-
 /// Retrieves the local tool version at **compile time** directly from the `Cargo.toml` file.
 ///
 /// This function leverages Rust's `env!` macro, which expands to the value of the

--- a/src/installers/brew.rs
+++ b/src/installers/brew.rs
@@ -7,7 +7,7 @@
 // manage tools available through Homebrew.
 
 // Standard library imports:
-use std::path::PathBuf;  // For ergonomic and platform-agnostic path manipulation.
+use std::path::PathBuf; // For ergonomic and platform-agnostic path manipulation.
 use std::process::Command; // For executing external commands (like `brew`) and capturing their output.
 
 // External crate imports:
@@ -23,7 +23,6 @@ use crate::schema::{ToolEntry, ToolState};
 use crate::{log_debug, log_error, log_info, log_warn};
 // Custom logging macros. These are used throughout the module to provide informative output
 // during the installation process, aiding in debugging and user feedback.
-
 
 /// Installs a tool using the Homebrew package manager.
 ///
@@ -50,18 +49,22 @@ use crate::{log_debug, log_error, log_info, log_warn};
 ///     `brew` command not found, `brew install` failed). Detailed error logging is performed
 ///     before returning `None` to provide context for the failure.
 pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
-    log_debug!("[Brew] Starting installation process for tool: {}", tool_entry.name.bold());
+    log_debug!(
+        "[Brew] Starting installation process for tool: {}",
+        tool_entry.name.bold()
+    );
 
     // 1. Validate Tool Name
     // Ensure that the `name` field is present in the `ToolEntry` and is not empty.
     // The tool name is essential for the `brew install` command.
     let name = &tool_entry.name;
     if name.is_empty() {
-        log_error!("[Brew] Tool name is empty in the configuration. Cannot proceed with Homebrew installation.");
+        log_error!(
+            "[Brew] Tool name is empty in the configuration. Cannot proceed with Homebrew installation."
+        );
         return None; // Abort if the tool name is missing.
     }
     log_debug!("[Brew] Tool name '{}' is validated.", name.blue());
-
 
     // 2. Prepare and Execute Homebrew Installation Command
     // Create a new `Command` instance to interact with the `brew` executable.
@@ -74,7 +77,10 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
     // For this implementation, we assume installation of the latest stable version.
     cmd.arg("install").arg(name);
 
-    log_info!("[Brew] Attempting to install {} using Homebrew...", name.bold());
+    log_info!(
+        "[Brew] Attempting to install {} using Homebrew...",
+        name.bold()
+    );
     // Log the exact command being executed for debugging purposes.
     log_debug!("[Brew] Executing command: {:#?}", cmd);
 
@@ -108,7 +114,6 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
 
     log_info!("[Brew] Successfully installed {}!", name.green());
 
-
     // 3. Determine the Installation Path
     // Homebrew installs binaries into a specific directory, which varies based on macOS architecture
     // (e.g., `/usr/local/bin` on Intel, `/opt/homebrew/bin` on Apple Silicon).
@@ -121,7 +126,9 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
 
     let brew_prefix = if brew_prefix_output.status.success() {
         // If `brew --prefix` was successful, take its stdout, trim whitespace, and convert to a String.
-        String::from_utf8_lossy(&brew_prefix_output.stdout).trim().to_string()
+        String::from_utf8_lossy(&brew_prefix_output.stdout)
+            .trim()
+            .to_string()
     } else {
         // If `brew --prefix` failed (e.g., even if `brew` is found, `--prefix` might error for some reason),
         // log a warning and default to a common, but potentially incorrect, path.
@@ -153,7 +160,10 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
         // The version field. Homebrew handles versions, so we can either use the `tool.version`
         // if specified (e.g., for specific formula@version syntax) or default to "latest"
         // to signify it's managed by Homebrew.
-        version: tool_entry.version.clone().unwrap_or_else(|| "latest".to_string()),
+        version: tool_entry
+            .version
+            .clone()
+            .unwrap_or_else(|| "latest".to_string()),
         // The detected absolute path to the installed binary.
         install_path: install_path.display().to_string(),
         // Flag indicating that this tool was installed by `devbox`.
@@ -172,5 +182,6 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
         // For direct URL installations: The original URL from which the tool was downloaded.
         url: tool_entry.url.clone(),
         executable_path_after_extract: None,
+        additional_cmd_executed: tool_entry.additional_cmd.clone(),
     })
 }

--- a/src/installers/cargo.rs
+++ b/src/installers/cargo.rs
@@ -6,7 +6,7 @@
 // handling common scenarios like specifying versions and passing additional Cargo options.
 
 // Standard library imports:
-use std::path::PathBuf;  // For ergonomic and platform-agnostic path manipulation.
+use std::path::PathBuf; // For ergonomic and platform-agnostic path manipulation.
 use std::process::{Command, Output}; // For executing external commands (like `cargo`) and capturing their output.
 
 // External crate imports:
@@ -22,7 +22,6 @@ use crate::schema::{ToolEntry, ToolState};
 use crate::{log_debug, log_error, log_info, log_warn};
 // Custom logging macros. These are used throughout the module to provide informative output
 // during the installation process, aiding in debugging and user feedback.
-
 
 /// Installs a Rust crate using the `cargo install` command.
 ///
@@ -46,7 +45,10 @@ use crate::{log_debug, log_error, log_info, log_warn};
 ///     is performed before returning `None` to provide context for the failure.
 pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
     // Start the installation process with a debug log, clearly indicating which tool (crate) is being processed.
-    log_debug!("[Cargo Installer] Attempting to install Cargo tool: {}", tool_entry.name.bold());
+    log_debug!(
+        "[Cargo Installer] Attempting to install Cargo tool: {}",
+        tool_entry.name.bold()
+    );
 
     // 1. Basic Validation: Check if `cargo` command is available.
     // Before attempting any installation, we must ensure that the Rust toolchain (specifically `cargo`)
@@ -69,7 +71,10 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
     if let Some(version) = &tool_entry.version {
         command_args.push("--version");
         command_args.push(version);
-        log_debug!("[Cargo Installer] Installing specific version: {}", version.cyan());
+        log_debug!(
+            "[Cargo Installer] Installing specific version: {}",
+            version.cyan()
+        );
     }
 
     // Add any additional options from `tool_entry.options`.
@@ -82,7 +87,11 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
     }
 
     // Log the full command that will be executed for debugging and user visibility.
-    log_info!("[Cargo Installer] Executing: {} {}", "cargo".cyan().bold(), command_args.join(" ").cyan());
+    log_info!(
+        "[Cargo Installer] Executing: {} {}",
+        "cargo".cyan().bold(),
+        command_args.join(" ").cyan()
+    );
 
     // 3. Execute `cargo install` Command
     // Spawn the `cargo` command with the prepared arguments and capture its standard output and error.
@@ -108,10 +117,16 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
         );
         // Log stdout and stderr, even on success, as they might contain useful information or warnings.
         if !output.stdout.is_empty() {
-            log_debug!("[Cargo Installer] Stdout: {}", String::from_utf8_lossy(&output.stdout));
+            log_debug!(
+                "[Cargo Installer] Stdout: {}",
+                String::from_utf8_lossy(&output.stdout)
+            );
         }
         if !output.stderr.is_empty() {
-            log_warn!("[Cargo Installer] Stderr (might contain warnings): {}", String::from_utf8_lossy(&output.stderr));
+            log_warn!(
+                "[Cargo Installer] Stderr (might contain warnings): {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
         }
 
         // 5. Determine Installation Path
@@ -120,14 +135,22 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
         let install_path = if let Ok(mut home) = std::env::var("HOME") {
             home.push_str("/.cargo/bin/"); // Append the standard Cargo bin directory.
             // Join the bin directory with the tool's name to get the full binary path.
-            PathBuf::from(home).join(&tool_entry.name).to_string_lossy().into_owned()
+            PathBuf::from(home)
+                .join(&tool_entry.name)
+                .to_string_lossy()
+                .into_owned()
         } else {
             // Fallback path if the HOME environment variable is not set.
             // This is a less reliable default but provides a reasonable guess.
-            log_warn!("[Cargo Installer] HOME environment variable not set, defaulting install path to /usr/local/bin/");
+            log_warn!(
+                "[Cargo Installer] HOME environment variable not set, defaulting install path to /usr/local/bin/"
+            );
             "/usr/local/bin/".to_string()
         };
-        log_debug!("[Cargo Installer] Determined installation path: {}", install_path.cyan());
+        log_debug!(
+            "[Cargo Installer] Determined installation path: {}",
+            install_path.cyan()
+        );
 
         // 6. Return `ToolState` for Tracking
         // If the installation was successful, construct a `ToolState` object. This object
@@ -135,7 +158,10 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
         // track it in its internal state file (`state.json`).
         Some(ToolState {
             // The version recorded for the tool. Uses the specified version or "latest" as a fallback.
-            version: tool_entry.version.clone().unwrap_or_else(|| "latest".to_string()),
+            version: tool_entry
+                .version
+                .clone()
+                .unwrap_or_else(|| "latest".to_string()),
             // The absolute path where the tool's executable was installed.
             install_path,
             // Flag indicating that this tool was installed by `devbox`.
@@ -155,6 +181,7 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
             // For direct URL installations: The original URL from which the tool was downloaded.
             url: tool_entry.url.clone(),
             executable_path_after_extract: None,
+            additional_cmd_executed: tool_entry.additional_cmd.clone(),
         })
     } else {
         // 7. Handle Failed Installation
@@ -169,7 +196,10 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
         );
         // Also log standard output on failure, as it might contain context for the error.
         if !output.stdout.is_empty() {
-            log_debug!("[Cargo Installer] Stdout (on failure): {}", String::from_utf8_lossy(&output.stdout));
+            log_debug!(
+                "[Cargo Installer] Stdout (on failure): {}",
+                String::from_utf8_lossy(&output.stdout)
+            );
         }
         None // Return `None` to indicate that the installation failed.
     }

--- a/src/installers/go.rs
+++ b/src/installers/go.rs
@@ -63,7 +63,10 @@ use std::path::PathBuf;
 /// * `None` if the `go` command is not found, or if the `go install` command fails for any reason
 ///   (e.g., compilation error, network issue, module not found).
 pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
-    log_debug!("[Go Installer] Attempting to install Go tool: {}", tool_entry.name.bold());
+    log_debug!(
+        "[Go Installer] Attempting to install Go tool: {}",
+        tool_entry.name.bold()
+    );
 
     // Basic validation: Ensure 'go' command is available in the system's PATH.
     // We check for its existence by attempting to run `go version`.
@@ -97,7 +100,11 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
 
     // Log the full command being executed for debugging and user visibility.
     // The command and its arguments are colored for better readability in the terminal.
-    log_info!("[Go Installer] Executing: {} {}", "go".cyan().bold(), command_args.join(" ").cyan());
+    log_info!(
+        "[Go Installer] Executing: {} {}",
+        "go".cyan().bold(),
+        command_args.join(" ").cyan()
+    );
 
     // Execute the `go install` command and capture its output.
     // This is a blocking call that waits for the command to complete.
@@ -123,11 +130,17 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
         );
         // Log standard output if available, usually contains build progress or confirmation.
         if !output.stdout.is_empty() {
-            log_debug!("[Go Installer] Stdout: {}", String::from_utf8_lossy(&output.stdout));
+            log_debug!(
+                "[Go Installer] Stdout: {}",
+                String::from_utf8_lossy(&output.stdout)
+            );
         }
         // Log standard error if available. Go commands might print warnings to stderr even on success.
         if !output.stderr.is_empty() {
-            log_warn!("[Go Installer] Stderr (might contain warnings): {}", String::from_utf8_lossy(&output.stderr));
+            log_warn!(
+                "[Go Installer] Stderr (might contain warnings): {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
         }
 
         // Determine the installation path.
@@ -137,7 +150,10 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
         let install_path = if let Ok(mut home) = std::env::var("HOME") {
             home.push_str("/go/bin/"); // Common default for `go install` if `GOPATH` isn't customized.
             // Join the base path with the tool's name, assuming the binary is named after the tool.
-            PathBuf::from(home).join(&tool_entry.name).to_string_lossy().into_owned()
+            PathBuf::from(home)
+                .join(&tool_entry.name)
+                .to_string_lossy()
+                .into_owned()
         } else {
             // Fallback path if HOME environment variable is not found.
             // This is less accurate but provides a placeholder.
@@ -148,7 +164,10 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
         // This `ToolState` will be serialized into `state.json` for persistent tracking.
         Some(ToolState {
             // Record the actual version used, or "latest" if not explicitly specified.
-            version: tool_entry.version.clone().unwrap_or_else(|| "latest".to_string()),
+            version: tool_entry
+                .version
+                .clone()
+                .unwrap_or_else(|| "latest".to_string()),
             // The determined installation path.
             install_path,
             // Mark as installed by this application.
@@ -168,6 +187,7 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
             options: tool_entry.options.clone(),
             url: tool_entry.url.clone(),
             executable_path_after_extract: None,
+            additional_cmd_executed: tool_entry.additional_cmd.clone(),
         })
     } else {
         // Handle failed installation.
@@ -178,11 +198,14 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
             "[Go Installer] Failed to install Go tool '{}'. Exit code: {}. Error: {}",
             tool_entry.name.bold().red(), // Tool name, colored red.
             output.status.code().unwrap_or(-1), // Exit code (default to -1 if not available).
-            stderr.red() // Standard error output, colored red.
+            stderr.red()                  // Standard error output, colored red.
         );
         // Also log stdout on failure, as it might contain useful context or partial build logs.
         if !output.stdout.is_empty() {
-            log_debug!("[Go Installer] Stdout (on failure): {}", String::from_utf8_lossy(&output.stdout));
+            log_debug!(
+                "[Go Installer] Stdout (on failure): {}",
+                String::from_utf8_lossy(&output.stdout)
+            );
         }
         None // Return None to indicate failure.
     }

--- a/src/installers/pip.rs
+++ b/src/installers/pip.rs
@@ -62,7 +62,10 @@ use std::path::PathBuf;
 /// * `None` if `pip` (or `pip3`) is not found, or if the `pip install` command fails for any reason
 ///     (e.g., network error, package not found, installation error).
 pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
-    log_debug!("[Pip Installer] Attempting to install Python package: {}", tool_entry.name.bold());
+    log_debug!(
+        "[Pip Installer] Attempting to install Python package: {}",
+        tool_entry.name.bold()
+    );
 
     // 1. Basic validation: Ensure 'pip' command is available on the system.
     // We prioritize 'pip3' as it's the standard for Python 3 installations.
@@ -107,7 +110,11 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
 
     // Log the full command being executed for debugging and user visibility.
     // The command and arguments are colored for better readability.
-    log_info!("[Pip Installer] Executing: {} {}", pip_command.cyan().bold(), command_args.join(" ").cyan());
+    log_info!(
+        "[Pip Installer] Executing: {} {}",
+        pip_command.cyan().bold(),
+        command_args.join(" ").cyan()
+    );
 
     // Execute the `pip install` command.
     // This is a blocking call that waits for the command to complete.
@@ -133,11 +140,17 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
         );
         // Log standard output if available, usually contains installation progress.
         if !output.stdout.is_empty() {
-            log_debug!("[Pip Installer] Stdout: {}", String::from_utf8_lossy(&output.stdout));
+            log_debug!(
+                "[Pip Installer] Stdout: {}",
+                String::from_utf8_lossy(&output.stdout)
+            );
         }
         // Log standard error if available. Pip sometimes prints warnings to stderr even on success.
         if !output.stderr.is_empty() {
-            log_warn!("[Pip Installer] Stderr (might contain warnings): {}", String::from_utf8_lossy(&output.stderr));
+            log_warn!(
+                "[Pip Installer] Stderr (might contain warnings): {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
         }
 
         // 3. Determine the installation path for `ToolState`.
@@ -151,21 +164,28 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
             // This is where many `pip --user` installed scripts/executables end up.
             home.push_str("/.local/bin/");
             // Construct the full path, joining the base path with the package name (assuming it might be an executable).
-            PathBuf::from(home).join(&tool_entry.name).to_string_lossy().into_owned()
+            PathBuf::from(home)
+                .join(&tool_entry.name)
+                .to_string_lossy()
+                .into_owned()
         } else {
             // If HOME directory cannot be determined, fall back to a generic system-wide bin path.
             // This is less accurate but provides a placeholder.
-            log_warn!("[Pip Installer] Could not determine HOME directory. Using generic fallback for pip package path.");
+            log_warn!(
+                "[Pip Installer] Could not determine HOME directory. Using generic fallback for pip package path."
+            );
             "/usr/local/bin/".to_string()
         };
-
 
         // 4. Return `ToolState` for Tracking.
         // Create and return a `ToolState` object to record this successful installation
         // in the application's persistent state (`state.json`).
         Some(ToolState {
             // Use the version specified in the config, or default to "latest" if not specified.
-            version: tool_entry.version.clone().unwrap_or_else(|| "latest".to_string()),
+            version: tool_entry
+                .version
+                .clone()
+                .unwrap_or_else(|| "latest".to_string()),
             // The approximated installation path.
             install_path,
             // Mark that this tool was installed by `setup-devbox`.
@@ -186,6 +206,7 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
             // For direct URL installations: The original URL from which the tool was downloaded.
             url: tool_entry.url.clone(),
             executable_path_after_extract: None,
+            additional_cmd_executed: tool_entry.additional_cmd.clone(),
         })
     } else {
         // 5. Handle Installation Failure.
@@ -196,11 +217,14 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
             "[Pip Installer] Failed to install Python package '{}'. Exit code: {}. Error: {}",
             tool_entry.name.bold().red(), // Package name, colored red.
             output.status.code().unwrap_or(-1), // Exit code (default to -1 if not available).
-            stderr.red() // Standard error output, colored red.
+            stderr.red()                  // Standard error output, colored red.
         );
         // Also log stdout on failure, as it might contain useful context.
         if !output.stdout.is_empty() {
-            log_debug!("[Pip Installer] Stdout (on failure): {}", String::from_utf8_lossy(&output.stdout));
+            log_debug!(
+                "[Pip Installer] Stdout (on failure): {}",
+                String::from_utf8_lossy(&output.stdout)
+            );
         }
         // Return `None` to signal that the installation was unsuccessful.
         None

--- a/src/installers/rustup.rs
+++ b/src/installers/rustup.rs
@@ -50,7 +50,10 @@ use std::env;
 /// * `None` if `rustup` is not found, a toolchain version is missing from the config,
 ///   or if any `rustup` command (toolchain install or component add) fails.
 pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
-    log_info!("[Rustup Installer] Attempting to install Rust-related tools based on entry: {}", tool_entry.name.bold());
+    log_info!(
+        "[Rustup Installer] Attempting to install Rust-related tools based on entry: {}",
+        tool_entry.name.bold()
+    );
     log_debug!("[Rustup Installer] ToolEntry details: {:#?}", tool_entry);
 
     // 1. Basic validation: Ensure 'rustup' command is available on the system.
@@ -81,7 +84,11 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
     // This command downloads and installs the specified Rust toolchain.
     let toolchain_command_args = vec!["toolchain", "install", &toolchain_name];
 
-    log_info!("[Rustup Installer] Executing: {} {}", "rustup".cyan().bold(), toolchain_command_args.join(" ").cyan());
+    log_info!(
+        "[Rustup Installer] Executing: {} {}",
+        "rustup".cyan().bold(),
+        toolchain_command_args.join(" ").cyan()
+    );
 
     let output_toolchain: Output = match Command::new("rustup")
         .args(&toolchain_command_args) // Pass all arguments to the `rustup` command.
@@ -102,11 +109,14 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
             "[Rustup Installer] Failed to install toolchain '{}'. Exit code: {}. Error: {}",
             toolchain_name.bold().red(), // Toolchain name
             output_toolchain.status.code().unwrap_or(-1), // Exit code (default to -1 if not available)
-            stderr.red() // Standard error output from rustup
+            stderr.red()                                  // Standard error output from rustup
         );
         // Provide debug info if stdout also has content on failure.
         if !output_toolchain.stdout.is_empty() {
-            log_debug!("[Rustup Installer] Stdout (on failure): {}", String::from_utf8_lossy(&output_toolchain.stdout));
+            log_debug!(
+                "[Rustup Installer] Stdout (on failure): {}",
+                String::from_utf8_lossy(&output_toolchain.stdout)
+            );
         }
         return None; // Installation failed.
     } else {
@@ -116,10 +126,16 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
             toolchain_name.bold().green()
         );
         if !output_toolchain.stdout.is_empty() {
-            log_debug!("[Rustup Installer] Stdout: {}", String::from_utf8_lossy(&output_toolchain.stdout));
+            log_debug!(
+                "[Rustup Installer] Stdout: {}",
+                String::from_utf8_lossy(&output_toolchain.stdout)
+            );
         }
         if !output_toolchain.stderr.is_empty() {
-            log_warn!("[Rustup Installer] Stderr (might contain warnings): {}", String::from_utf8_lossy(&output_toolchain.stderr));
+            log_warn!(
+                "[Rustup Installer] Stderr (might contain warnings): {}",
+                String::from_utf8_lossy(&output_toolchain.stderr)
+            );
         }
     }
 
@@ -129,9 +145,19 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
     if let Some(components) = &tool_entry.options {
         for component in components {
             // Command to add a component to a specific toolchain.
-            let component_command_args = vec!["component", "add", component, "--toolchain", &toolchain_name];
+            let component_command_args = vec![
+                "component",
+                "add",
+                component,
+                "--toolchain",
+                &toolchain_name,
+            ];
 
-            log_info!("[Rustup Installer] Executing: {} {}", "rustup".cyan().bold(), component_command_args.join(" ").cyan());
+            log_info!(
+                "[Rustup Installer] Executing: {} {}",
+                "rustup".cyan().bold(),
+                component_command_args.join(" ").cyan()
+            );
 
             let output_component: Output = match Command::new("rustup")
                 .args(&component_command_args)
@@ -142,9 +168,9 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
                     // Log error if component command failed to execute.
                     log_error!(
                         "[Rustup Installer] Failed to execute 'rustup component add' for '{}' on toolchain '{}': {}",
-                        component.bold().red(), // Component name
+                        component.bold().red(),      // Component name
                         toolchain_name.bold().red(), // Toolchain name
-                        e // Error details
+                        e                            // Error details
                     );
                     // Decided to return None here. If a core component fails,
                     // the entire Rust setup might be considered incomplete/broken.
@@ -158,7 +184,9 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
                     "[Rustup Installer] Failed to add component '{}'. Exit code: {}. Stderr: {}",
                     component.bold().red(), // Component name (Argument 1)
                     output_component.status.code().unwrap_or(-1), // Exit code (Argument 2)
-                    String::from_utf8_lossy(&output_component.stderr).trim().red() // Stderr (Argument 3)
+                    String::from_utf8_lossy(&output_component.stderr)
+                        .trim()
+                        .red()  // Stderr (Argument 3)
                 );
                 // Similar to toolchain installation, a failed component addition
                 // is treated as a fatal error for this tool's installation.
@@ -173,10 +201,16 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
                     toolchain_name.bold().green()
                 );
                 if !output_component.stdout.is_empty() {
-                    log_debug!("[Rustup Installer] Stdout: {}", String::from_utf8_lossy(&output_component.stdout));
+                    log_debug!(
+                        "[Rustup Installer] Stdout: {}",
+                        String::from_utf8_lossy(&output_component.stdout)
+                    );
                 }
                 if !output_component.stderr.is_empty() {
-                    log_warn!("[Rustup Installer] Stderr (might contain warnings): {}", String::from_utf8_lossy(&output_component.stderr));
+                    log_warn!(
+                        "[Rustup Installer] Stderr (might contain warnings): {}",
+                        String::from_utf8_lossy(&output_component.stderr)
+                    );
                 }
             }
         }
@@ -191,24 +225,27 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
     } else {
         // Fallback if HOME directory cannot be determined, though this might be less accurate
         // for rustup which heavily relies on the user's home directory structure.
-        log_warn!("[Rustup Installer] Could not determine HOME directory. Using generic fallback for toolchain path.");
+        log_warn!(
+            "[Rustup Installer] Could not determine HOME directory. Using generic fallback for toolchain path."
+        );
         "/usr/local/bin/".to_string()
     };
 
     // Return a `ToolState` object indicating successful installation.
     // This `ToolState` will be serialized into `state.json` to track installed tools.
     Some(ToolState {
-        version: toolchain_name, // The installed toolchain version.
-        install_path,           // The path where the toolchain binaries are expected.
+        version: toolchain_name,                  // The installed toolchain version.
+        install_path,              // The path where the toolchain binaries are expected.
         installed_by_devbox: true, // Mark as installed by this application.
         install_method: "rustup".to_string(), // The method used for installation.
         renamed_to: tool_entry.rename_to.clone(), // Any rename preference from the config.
         package_type: "rust-toolchain".to_string(), // Categorize the installed item.
-        repo: None, // Not applicable for rustup (no direct Git repo tracking).
-        tag: None,  // Not applicable for rustup (no direct Git tag tracking).
+        repo: None,                // Not applicable for rustup (no direct Git repo tracking).
+        tag: None,                 // Not applicable for rustup (no direct Git tag tracking).
         options: tool_entry.options.clone(), // Store the components that were attempted to be added.
         // For direct URL installations: The original URL from which the tool was downloaded.
         url: tool_entry.url.clone(),
         executable_path_after_extract: None,
+        additional_cmd_executed: tool_entry.additional_cmd.clone(),
     })
 }


### PR DESCRIPTION
### Added new parameter

- Added support for `additional_cmd` for `ToolEntry`
- Idea is to execute any additional commands after the tool is installed
- Mostly it will be useful for **GitHub** but available to all installers
- `ToolState` has also been modified

### Example

```
  - name: helix
    version: 25.07.1
    source: github
    repo: helix-editor/helix
    tag: 25.07.1
    rename_to: hx
    additional_cmd:
      - mkdir -p $HOME/.config/helix
      - cp -r runtime $HOME/.config/helix
      - cp -r contrib $HOME/.config/helix
```