### PR TITLE
bug: Change field name for `ToolEntry` and `ToolState`

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -46,7 +46,7 @@ commit_preprocessors = [
 # regex for parsing and grouping commits
 commit_parsers = [
     { message = "^feat", group = "🚀 Features" },
-    { message = "^fix", group = "🐛 Bug Fixes" },
+    { message = "^bug", group = "🐛 Bug Fixes" },
     { message = "^doc", group = "📚 Documentation" },
     { message = "^perf", group = "⚡ Performance" },
     { message = "^refactor", group = "♻️ Refactor" },

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -143,7 +143,7 @@ fn sync_state_to_configs(state_path: &PathBuf, output_dir: &PathBuf) {
             rename_to: tool_state.renamed_to,
             options: tool_state.options,
             executable_path_after_extract: tool_state.executable_path_after_extract,
-            additional_cmd: tool_state.additional_cmd_executed,
+            post_installation_hooks: tool_state.executed_post_installation_hooks,
             configuration_manager: Default::default(),
         };
         tool_entry

--- a/src/installers/brew.rs
+++ b/src/installers/brew.rs
@@ -199,7 +199,7 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
         last_updated: Some(current_timestamp()),
         // Record any additional commands that were executed during installation.
         // This is useful for tracking what was done and potentially for cleanup during uninstall.
-        additional_cmd_executed: tool_entry.additional_cmd.clone(),
+        executed_post_installation_hooks: tool_entry.post_installation_hooks.clone(),
         configuration_manager: None,
     })
 }

--- a/src/installers/cargo.rs
+++ b/src/installers/cargo.rs
@@ -205,7 +205,7 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
             executable_path_after_extract: None,
             // Record any additional commands that were executed during installation.
             // This is useful for tracking what was done and potentially for cleanup during uninstall.
-            additional_cmd_executed: tool_entry.additional_cmd.clone(),
+            executed_post_installation_hooks: tool_entry.post_installation_hooks.clone(),
             configuration_manager: None,
         })
     } else {

--- a/src/installers/github.rs
+++ b/src/installers/github.rs
@@ -48,7 +48,7 @@ use crate::schemas::common::{Release, ReleaseAsset};
 use crate::schemas::state_file::ToolState;
 use crate::schemas::tools::ToolEntry;
 
-use crate::libs::tool_installer::execute_post_installation_commands;
+use crate::libs::tool_installer::execute_post_installation_hooks;
 use crate::libs::utilities::assets::{current_timestamp, install_dmg};
 // Custom logging macros. These are used throughout the module to provide informative output
 // during the installation process, aiding in debugging and user feedback.
@@ -583,7 +583,7 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
     // in the tool configuration. These commands are often used for post-installation setup,
     // such as copying configuration files, creating directories, or setting up symbolic links.
     // Optional - failure won't stop installation
-    let executed_additional_commands = execute_post_installation_commands(
+    let executed_additional_commands = execute_post_installation_hooks(
         "[GitHub Installer]",
         tool_entry,
         &additional_cmd_working_dir,
@@ -637,7 +637,7 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
         executable_path_after_extract: None,
         // Record any additional commands that were executed during installation.
         // This is useful for tracking what was done and potentially for cleanup during uninstall.
-        additional_cmd_executed: executed_additional_commands,
+        executed_post_installation_hooks: executed_additional_commands,
         configuration_manager: None,
     })
 }

--- a/src/installers/go.rs
+++ b/src/installers/go.rs
@@ -222,7 +222,7 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
             executable_path_after_extract: None,
             // Record any additional commands that were executed during installation.
             // This is useful for tracking what was done and potentially for cleanup during uninstall.
-            additional_cmd_executed: tool_entry.additional_cmd.clone(),
+            executed_post_installation_hooks: tool_entry.post_installation_hooks.clone(),
             configuration_manager: None,
         })
     } else {

--- a/src/installers/pip.rs
+++ b/src/installers/pip.rs
@@ -227,7 +227,7 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
             executable_path_after_extract: None,
             // Record any additional commands that were executed during installation.
             // This is useful for tracking what was done and potentially for cleanup during uninstall.
-            additional_cmd_executed: tool_entry.additional_cmd.clone(),
+            executed_post_installation_hooks: tool_entry.post_installation_hooks.clone(),
             configuration_manager: None,
         })
     } else {

--- a/src/installers/rustup.rs
+++ b/src/installers/rustup.rs
@@ -282,7 +282,7 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
         executable_path_after_extract: None,
         // Record any additional commands that were executed during installation.
         // This is useful for tracking what was done and potentially for cleanup during uninstall.
-        additional_cmd_executed: tool_entry.additional_cmd.clone(),
+        executed_post_installation_hooks: tool_entry.post_installation_hooks.clone(),
         configuration_manager: None,
     })
 }

--- a/src/installers/url.rs
+++ b/src/installers/url.rs
@@ -375,7 +375,7 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
         executable_path_after_extract: executable_path_after_extract_for_state,
         // Record any additional commands that were executed during installation.
         // This is useful for tracking what was done and potentially for cleanup during uninstall.
-        additional_cmd_executed: tool_entry.additional_cmd.clone(),
+        executed_post_installation_hooks: tool_entry.post_installation_hooks.clone(),
         configuration_manager: None,
     })
 }

--- a/src/installers/uv.rs
+++ b/src/installers/uv.rs
@@ -19,7 +19,7 @@ use crate::{log_debug, log_error, log_info, log_warn};
 // For adding color to terminal output.
 use colored::Colorize;
 // For executing external commands and capturing their output.
-use crate::libs::tool_installer::execute_post_installation_commands;
+use crate::libs::tool_installer::execute_post_installation_hooks;
 use crate::libs::utilities::misc_utils::{default_python_path, extract_version_number};
 use serde_json::Value;
 use std::process::{Command, Output};
@@ -174,7 +174,7 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
             std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
 
         // Execute additional commands (optional - failure won't stop installation)
-        let executed_additional_commands = execute_post_installation_commands(
+        let executed_additional_commands = execute_post_installation_hooks(
             "[UV Installer]",
             tool_entry,
             &additional_cmd_working_dir,
@@ -234,7 +234,7 @@ pub fn install(tool_entry: &ToolEntry) -> Option<ToolState> {
             // Record any additional commands that were executed during installation.
             // This is useful for tracking what was done and potentially for cleanup during uninstall.
             // additional_cmd_executed: tool_entry.additional_cmd.clone(),
-            additional_cmd_executed: executed_additional_commands,
+            executed_post_installation_hooks: executed_additional_commands,
             configuration_manager: None,
         })
     } else {

--- a/src/libs/tool_installer.rs
+++ b/src/libs/tool_installer.rs
@@ -34,7 +34,7 @@ use crate::libs::state_management::save_state_to_file;
 use crate::libs::utilities::assets::{is_timestamp_older_than, parse_duration, time_since};
 use crate::libs::utilities::misc_utils::format_duration;
 use crate::libs::utilities::platform::{
-    check_installer_command_available, execute_additional_commands,
+    check_installer_command_available, execute_hooks,
 };
 use crate::schemas::configuration_management::ConfigurationManagerProcessor;
 // Import data schemas and the configuration processor
@@ -790,15 +790,15 @@ pub fn install_tools(
 ///
 /// ## Returns
 /// `Some(Vec<String>)` with executed commands if successful, `None` if no commands or failure
-pub fn execute_post_installation_commands(
+pub fn execute_post_installation_hooks(
     installer_prefix: &str,
     tool_entry: &ToolEntry,
     working_directory: &std::path::Path,
 ) -> Option<Vec<String>> {
     // Return `None` if there are no additional commands.
-    let additional_commands = tool_entry.additional_cmd.as_ref()?;
+    let post_install_hooks = tool_entry.post_installation_hooks.as_ref()?;
 
-    if additional_commands.is_empty() {
+    if post_install_hooks.is_empty() {
         log_debug!(
             "[Tools] {} No additional commands for {}",
             installer_prefix,
@@ -810,7 +810,7 @@ pub fn execute_post_installation_commands(
     log_info!(
         "[Tools] {} Executing {} additional command(s) for {}",
         installer_prefix,
-        additional_commands.len().to_string().yellow(),
+        post_install_hooks.len().to_string().yellow(),
         tool_entry.name.bold()
     );
 
@@ -821,9 +821,9 @@ pub fn execute_post_installation_commands(
     );
 
     // Delegate the actual command execution to a separate utility function.
-    match execute_additional_commands(
+    match execute_hooks(
         installer_prefix,
-        additional_commands,
+        post_install_hooks,
         working_directory,
         &tool_entry.name,
     ) {

--- a/src/libs/tool_installer.rs
+++ b/src/libs/tool_installer.rs
@@ -33,9 +33,7 @@ use crate::libs::configuration_manager::ConfigurationEvaluationResult;
 use crate::libs::state_management::save_state_to_file;
 use crate::libs::utilities::assets::{is_timestamp_older_than, parse_duration, time_since};
 use crate::libs::utilities::misc_utils::format_duration;
-use crate::libs::utilities::platform::{
-    check_installer_command_available, execute_hooks,
-};
+use crate::libs::utilities::platform::{check_installer_command_available, execute_hooks};
 use crate::schemas::configuration_management::ConfigurationManagerProcessor;
 // Import data schemas and the configuration processor
 use crate::schemas::state_file::{DevBoxState, ToolState};

--- a/src/libs/utilities/platform.rs
+++ b/src/libs/utilities/platform.rs
@@ -354,7 +354,7 @@ pub fn check_installer_command_available(command_name: &str) -> Result<(), Insta
 /// - No sandboxing or privilege restriction is applied
 /// - Input validation should be performed by the caller to prevent command injection
 /// - Consider the security implications of executing user-provided commands
-pub fn execute_additional_commands(
+pub fn execute_hooks(
     installer_prefix: &str,
     commands: &[String],
     working_dir: &std::path::Path,

--- a/src/schemas/state_file.rs
+++ b/src/schemas/state_file.rs
@@ -311,7 +311,7 @@ pub struct ToolState {
     /// ## Default Behavior
     /// `#[serde(default)]` ensures empty command lists are stored as `None`.
     #[serde(default)]
-    pub additional_cmd_executed: Option<Vec<String>>,
+    pub executed_post_installation_hooks: Option<Vec<String>>,
 
     /// Configuration management state for this tool.
     ///

--- a/src/schemas/tools.rs
+++ b/src/schemas/tools.rs
@@ -438,14 +438,14 @@ pub struct ToolEntry {
     /// ## Examples
     ///
     /// ```yaml
-    /// additional_cmd:
+    /// post_installation_hooks:
     ///   - "cp -r runtime $HOME/.config/helix/"
     ///   - "mkdir -p $HOME/.local/share/helix"
     ///   - "ln -sf $(pwd)/themes $HOME/.config/helix/themes"
     ///   - "chmod +x contrib/completion.sh"
     /// ```
     #[serde(default)]
-    pub additional_cmd: Option<Vec<String>>,
+    pub post_installation_hooks: Option<Vec<String>>,
 
     /// Configuration file management settings for this tool.
     ///


### PR DESCRIPTION
## Field name changes for `ToolEntry` and `ToolState` to reflect plural entries:

- Changed `additional_cmd` to `post_installation_hooks` in `ToolEntry`
- Changed `additional_cmd_executed` to `executed_post_installation_hooks` in `ToolState`
- Changed the related function and variable names to reflect the same change
 