### PR TITLE
PR: Multiple Fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1071,9 +1071,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1331,9 +1331,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ flate2 = "1.1.2"
 # 'tar' is a crate for creating, reading, and extracting `.tar` archives.
 # These archives are commonly used on Unix-like systems to bundle multiple files into one.
 # It's often used in conjunction with a compression library like `flate2` or `bzip2`.
-tar = "0.4.44"
+tar = "0.4.45"
 
 # 'zip' is a library for working with `.zip` archives.
 # Zip files are another popular format for bundling and compressing files, especially common on Windows.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ tempfile = "3.20.0"
 # 'xz2' provides bindings to the `liblzma` (XZ) compression library.
 # This crate allows your application to handle `.xz` compressed files and `.tar.xz` archives,
 # which are known for high compression ratios.
-xz2 = "0.1.7"
+xz2 = { version = "0.1.7", features = ["static"] }
 
 # 'goblin' is a crate for parsing various binary executable formats (ELF, Mach-O, PE).
 # This can be useful for inspecting executable files, understanding their structure,

--- a/src/commands/bootstrap.rs
+++ b/src/commands/bootstrap.rs
@@ -614,8 +614,8 @@ impl Bootstrapper {
             .map_err(|e| BootstrapError::BrewDownloadFailed(e.to_string()))?;
 
         // Create a temporary file for the script
-        let mut temp_file = tempfile::NamedTempFile::new()
-            .map_err(BootstrapError::BrewInstallationStartFailed)?;
+        let mut temp_file =
+            tempfile::NamedTempFile::new().map_err(BootstrapError::BrewInstallationStartFailed)?;
 
         temp_file
             .write_all(script_content.as_bytes())

--- a/src/core/binary.rs
+++ b/src/core/binary.rs
@@ -456,49 +456,26 @@ pub fn move_and_rename_binary(
         "[SDB::Tools::{tool_source}::BinaryInstaller] Source file exists, proceeding with operation"
     );
 
-    // Determine the final destination path based on rename_to
-    let final_destination = if let Some(ref new_name) = tool_entry.rename_to {
+    // Determine the final destination path based on rename_to or tool_name
+    let final_destination = {
+        let target_name = tool_entry.rename_to.as_ref().unwrap_or(&tool_entry.name);
         log_debug!(
-            "[SDB::Tools::{tool_source}::BinaryInstaller] rename_to is set to: {}",
-            new_name.green()
+            "[SDB::Tools::{tool_source}::BinaryInstaller] Target filename: {}",
+            target_name.green()
         );
 
-        // Check if 'to' is a directory
         if to.is_dir() {
             log_debug!(
-                "[SDB::Tools::{tool_source}::BinaryInstaller] Destination is a directory, appending new filename: {}",
-                new_name
+                "[SDB::Tools::{tool_source}::BinaryInstaller] Destination is a directory, appending target filename"
             );
-            to.join(new_name)
-        } else {
+            to.join(target_name)
+        } else if to.parent().is_some() {
             log_debug!(
-                "[SDB::Tools::{tool_source}::BinaryInstaller] Destination appears to be a file path, using parent directory and appending new filename"
+                "[SDB::Tools::{tool_source}::BinaryInstaller] Destination appears to be a file path, using its parent and appending target filename"
             );
-            // If 'to' has a parent, join new_name to parent; otherwise use 'to' as is
-            if let Some(parent) = to.parent() {
-                parent.join(new_name)
-            } else {
-                PathBuf::from(new_name)
-            }
-        }
-    } else {
-        log_debug!(
-            "[SDB::Tools::{tool_source}::BinaryInstaller] rename_to is not set, will copy without renaming"
-        );
-
-        // If no rename, use the original filename
-        if to.is_dir() {
-            log_debug!(
-                "[SDB::Tools::{tool_source}::BinaryInstaller] Destination is a directory, appending original filename"
-            );
-            let file_name = from.file_name().ok_or_else(|| {
-                log_error!("[SDB::Tools::{tool_source}::BinaryInstaller] Source path has no filename component");
-                io::Error::new(io::ErrorKind::InvalidInput, "[SDB::Tools::{tool_source}::BinaryInstaller] Source path has no filename")
-            })?;
-            to.join(file_name)
+            to.parent().unwrap().join(target_name)
         } else {
-            log_debug!("[SDB::Tools::{tool_source}::BinaryInstaller] Using destination path as-is");
-            to.to_path_buf()
+            PathBuf::from(target_name)
         }
     };
 
@@ -529,83 +506,63 @@ pub fn move_and_rename_binary(
         log_debug!("[SDB::Tools::{tool_source}::BinaryInstaller] No parent directories to create");
     }
 
-    // Decide operation based on rename_to
-    if tool_entry.rename_to.is_none() {
-        log_debug!(
-            "[SDB::Tools::{tool_source}::BinaryInstaller] Performing simple copy operation (no rename)"
-        );
-        log_debug!(
-            "[SDB::Tools::{tool_source}::BinaryInstaller] Copying from {} to {}",
-            from.to_string_lossy().yellow(),
-            final_destination.to_string_lossy().cyan()
-        );
+    log_debug!("[SDB::Tools::{tool_source}::BinaryInstaller] Performing rename/move operation");
+    log_debug!(
+        "[SDB::Tools::{tool_source}::BinaryInstaller] Attempting fs::rename from {} to {}",
+        from.to_string_lossy().yellow(),
+        final_destination.to_string_lossy().cyan()
+    );
 
-        fs::copy(from, &final_destination)?;
+    // Perform the move operation using `fs::rename`.
+    match fs::rename(from, &final_destination) {
+        Ok(_) => {
+            log_debug!(
+                "[SDB::Tools::{tool_source}::BinaryInstaller] Binary renamed/moved successfully to {}",
+                final_destination.to_string_lossy().green()
+            );
+            Ok(())
+        }
+        // Handle the specific error case where `fs::rename` fails due to `CrossesDevices`.
+        Err(e) if e.kind() == io::ErrorKind::CrossesDevices => {
+            log_warn!(
+                "[SDB::Tools::{tool_source}::BinaryInstaller] Cross-device link detected (error: {}), falling back to copy and remove",
+                e
+            );
+            log_debug!(
+                "[SDB::Tools::{tool_source}::BinaryInstaller] Fallback: copying from {} to {}",
+                from.to_string_lossy().yellow(),
+                final_destination.to_string_lossy().cyan()
+            );
 
-        log_debug!(
-            "[SDB::Tools::{tool_source}::BinaryInstaller] Binary copied successfully to {}",
-            final_destination.to_string_lossy().green()
-        );
-        Ok(())
-    } else {
-        log_debug!("[SDB::Tools::{tool_source}::BinaryInstaller] Performing rename/move operation");
-        log_debug!(
-            "[SDB::Tools::{tool_source}::BinaryInstaller] Attempting fs::rename from {} to {}",
-            from.to_string_lossy().yellow(),
-            final_destination.to_string_lossy().cyan()
-        );
+            fs::copy(from, &final_destination)?;
+            log_debug!(
+                "[SDB::Tools::{tool_source}::BinaryInstaller] Fallback: copy completed successfully"
+            );
+            log_debug!(
+                "[SDB::Tools::{tool_source}::BinaryInstaller] Fallback: removing original file at {}",
+                from.to_string_lossy()
+            );
 
-        // Perform the move operation using `fs::rename`.
-        match fs::rename(from, &final_destination) {
-            Ok(_) => {
-                log_debug!(
-                    "[SDB::Tools::{tool_source}::BinaryInstaller] Binary renamed/moved successfully to {}",
-                    final_destination.to_string_lossy().green()
-                );
-                Ok(())
-            }
-            // Handle the specific error case where `fs::rename` fails due to `CrossesDevices`.
-            Err(e) if e.kind() == io::ErrorKind::CrossesDevices => {
-                log_warn!(
-                    "[SDB::Tools::{tool_source}::BinaryInstaller] Cross-device link detected (error: {}), falling back to copy and remove",
-                    e
-                );
-                log_debug!(
-                    "[SDB::Tools::{tool_source}::BinaryInstaller] Fallback: copying from {} to {}",
-                    from.to_string_lossy().yellow(),
-                    final_destination.to_string_lossy().cyan()
-                );
-
-                fs::copy(from, &final_destination)?;
-                log_debug!(
-                    "[SDB::Tools::{tool_source}::BinaryInstaller] Fallback: copy completed successfully"
-                );
-                log_debug!(
-                    "[SDB::Tools::{tool_source}::BinaryInstaller] Fallback: removing original file at {}",
-                    from.to_string_lossy()
-                );
-
-                fs::remove_file(from)?;
-                log_debug!(
-                    "[SDB::Tools::{tool_source}::BinaryInstaller] Fallback: original file removed from {}",
-                    from.to_string_lossy()
-                );
-                log_debug!(
-                    "[SDB::Tools::{tool_source}::BinaryInstaller] Binary copied and original removed successfully. Final location: {}",
-                    final_destination.to_string_lossy().green()
-                );
-                Ok(())
-            }
-            Err(e) => {
-                log_error!(
-                    "[SDB::Tools::{tool_source}::BinaryInstaller] Failed to rename binary from {} to {}: {} (error kind: {:?})",
-                    from.to_string_lossy(),
-                    final_destination.to_string_lossy(),
-                    e,
-                    e.kind()
-                );
-                Err(e)
-            }
+            fs::remove_file(from)?;
+            log_debug!(
+                "[SDB::Tools::{tool_source}::BinaryInstaller] Fallback: original file removed from {}",
+                from.to_string_lossy()
+            );
+            log_debug!(
+                "[SDB::Tools::{tool_source}::BinaryInstaller] Binary copied and original removed successfully. Final location: {}",
+                final_destination.to_string_lossy().green()
+            );
+            Ok(())
+        }
+        Err(e) => {
+            log_error!(
+                "[SDB::Tools::{tool_source}::BinaryInstaller] Failed to rename binary from {} to {}: {} (error kind: {:?})",
+                from.to_string_lossy(),
+                final_destination.to_string_lossy(),
+                e,
+                e.kind()
+            );
+            Err(e)
         }
     }
 }
@@ -684,6 +641,70 @@ pub fn make_executable(path: &Path, tool_entry: &ToolEntry, tool_source: String)
         file_path.to_string_lossy().green()
     );
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_move_and_rename_binary_with_tool_name() {
+        let temp_dir = tempdir().unwrap();
+        let source_dir = tempdir().unwrap();
+        let source_file = source_dir.path().join("downloaded-binary");
+        File::create(&source_file).unwrap();
+
+        let tool_entry = ToolEntry {
+            name: "mytool".to_string(),
+            version: None,
+            source: crate::schemas::tools_enums::SourceType::Github,
+            url: None,
+            repo: None,
+            tag: None,
+            rename_to: None,
+            options: None,
+            executable_path_after_extract: None,
+            post_installation_hooks: None,
+            configuration_manager: Default::default(),
+        };
+
+        let dest_dir = temp_dir.path().to_path_buf();
+        move_and_rename_binary(&source_file, &dest_dir, &tool_entry, "GitHub".to_string()).unwrap();
+
+        assert!(dest_dir.join("mytool").exists());
+        assert!(!source_file.exists());
+    }
+
+    #[test]
+    fn test_move_and_rename_binary_with_rename_to() {
+        let temp_dir = tempdir().unwrap();
+        let source_dir = tempdir().unwrap();
+        let source_file = source_dir.path().join("downloaded-binary");
+        File::create(&source_file).unwrap();
+
+        let tool_entry = ToolEntry {
+            name: "mytool".to_string(),
+            version: None,
+            source: crate::schemas::tools_enums::SourceType::Github,
+            url: None,
+            repo: None,
+            tag: None,
+            rename_to: Some("myrenamedtool".to_string()),
+            options: None,
+            executable_path_after_extract: None,
+            post_installation_hooks: None,
+            configuration_manager: Default::default(),
+        };
+
+        let dest_dir = temp_dir.path().to_path_buf();
+        move_and_rename_binary(&source_file, &dest_dir, &tool_entry, "GitHub".to_string()).unwrap();
+
+        assert!(dest_dir.join("myrenamedtool").exists());
+        assert!(!dest_dir.join("mytool").exists());
+        assert!(!source_file.exists());
+    }
 }
 
 // Provide a dummy implementation for `make_executable` on non-Unix systems to avoid compilation errors.

--- a/src/core/platform.rs
+++ b/src/core/platform.rs
@@ -562,20 +562,17 @@ mod tests {
 
     #[test]
     fn test_is_excluded_asset() {
-        assert!(is_excluded_asset(&"b3sums".to_lowercase()));
-        assert!(is_excluded_asset(&"B3SUMS".to_lowercase()));
-        assert!(is_excluded_asset(&"shasums".to_lowercase()));
-        assert!(is_excluded_asset(&"sha256sums".to_lowercase()));
-        assert!(is_excluded_asset(&"checksums.txt".to_lowercase()));
-        assert!(is_excluded_asset(&"license.md".to_lowercase()));
-        assert!(is_excluded_asset(&"readme.txt".to_lowercase()));
-        assert!(is_excluded_asset(&"changelog".to_lowercase()));
-        assert!(is_excluded_asset(&"mytool.tar.gz.sig".to_lowercase()));
-        assert!(is_excluded_asset(&"mytool.asc".to_lowercase()));
+        assert!(is_excluded_asset("b3sums"));
+        assert!(is_excluded_asset("shasums"));
+        assert!(is_excluded_asset("sha256sums"));
+        assert!(is_excluded_asset("checksums.txt"));
+        assert!(is_excluded_asset("license.md"));
+        assert!(is_excluded_asset("readme.txt"));
+        assert!(is_excluded_asset("changelog"));
+        assert!(is_excluded_asset("mytool.tar.gz.sig"));
+        assert!(is_excluded_asset("mytool.asc"));
 
-        assert!(!is_excluded_asset(
-            &"mytool-darwin-arm64.tar.gz".to_lowercase()
-        ));
-        assert!(!is_excluded_asset(&"mytool".to_lowercase()));
+        assert!(!is_excluded_asset("mytool-darwin-arm64.tar.gz"));
+        assert!(!is_excluded_asset("mytool"));
     }
 }

--- a/src/core/platform.rs
+++ b/src/core/platform.rs
@@ -158,9 +158,21 @@ fn is_excluded_asset(asset_name_lower: &str) -> bool {
         asset_name_lower.contains("debug") ||
         asset_name_lower.contains("checksum") ||
         asset_name_lower.contains("sha256") ||
+        asset_name_lower.contains("sha512") ||
+        asset_name_lower.contains("sha1") ||
+        asset_name_lower.contains("md5") ||
+        asset_name_lower.contains("sums") || // Matches B3SUMS, SHASUMS, etc.
+        asset_name_lower.contains("license") ||
+        asset_name_lower.contains("readme") ||
+        asset_name_lower.contains("changelog") ||
         asset_name_lower.contains("tar.gz.sig") || // Common signature file for tar.gz
+        asset_name_lower.contains(".sig") || // General signature
+        asset_name_lower.contains(".sign") || // General signature
         std::path::Path::new(asset_name_lower).extension
-            ().is_some_and(|ext| ext.eq_ignore_ascii_case("asc")); // Common detached signature file extension
+            ().is_some_and(|ext| {
+                let e = ext.to_string_lossy().to_lowercase();
+                ["asc", "txt", "md", "html", "pdf", "sig", "sign"].contains(&e.as_str())
+            });
 
     if is_excluded {
         log_debug!(
@@ -546,5 +558,24 @@ mod tests {
         // Truly universal DMG should match both
         assert!(asset_matches_platform("MyTool.dmg", "macos", "x86_64"));
         assert!(asset_matches_platform("MyTool.dmg", "macos", "arm64"));
+    }
+
+    #[test]
+    fn test_is_excluded_asset() {
+        assert!(is_excluded_asset(&"b3sums".to_lowercase()));
+        assert!(is_excluded_asset(&"B3SUMS".to_lowercase()));
+        assert!(is_excluded_asset(&"shasums".to_lowercase()));
+        assert!(is_excluded_asset(&"sha256sums".to_lowercase()));
+        assert!(is_excluded_asset(&"checksums.txt".to_lowercase()));
+        assert!(is_excluded_asset(&"license.md".to_lowercase()));
+        assert!(is_excluded_asset(&"readme.txt".to_lowercase()));
+        assert!(is_excluded_asset(&"changelog".to_lowercase()));
+        assert!(is_excluded_asset(&"mytool.tar.gz.sig".to_lowercase()));
+        assert!(is_excluded_asset(&"mytool.asc".to_lowercase()));
+
+        assert!(!is_excluded_asset(
+            &"mytool-darwin-arm64.tar.gz".to_lowercase()
+        ));
+        assert!(!is_excluded_asset(&"mytool".to_lowercase()));
     }
 }


### PR DESCRIPTION
##  Pull Request Summary

This PR focuses on enhancing the GitHub installer's reliability, removing a runtime dependency for better portability, and addressing security vulnerabilities.

###  1. GitHub Installer Fixes
   - **Non-Binary Asset Filtering:** Improved `is_excluded_asset` to correctly ignore checksums (B3SUMS, SHASUMS), licenses, and documentation files.
   - **Consistent Binary Naming:** Fixed `move_and_rename_binary` to ensure downloaded binaries are always correctly named/renamed to the tool's expected name (e.g., pulumi),
     even when downloaded from a generic URL.
   - **Robust Move Logic:** Refactored move operations to use `fs::rename` with a robust copy-and-remove fallback for cross-device filesystem moves.

###  2. Portability Improvements
   - **Static XZ Linking:** Updated `xz2` crate configuration to link `liblzma` statically, removing the runtime dependency on the system library. Verified via `otool -L`.

###  3. Security & Quality
   - **Vulnerability Fixes:**
     - Upgraded tar from `0.4.44` to `0.4.45` (Fixes RUSTSEC-2026-0068, RUSTSEC-2026-0067).
     - Upgraded transitive dependency `rustls-webpki` from `0.103.9` to `0.103.10` (Fixes RUSTSEC-2026-0049).
   - **Regression Testing:** Added comprehensive unit tests for asset exclusion and binary renaming in `src/core/platform.rs` and `src/core/binary.rs`.
   - **Pre-PR Validation:** All checks in make pre-pr (audit, formatting, unused deps, builds) passed successfully.

  Verification

   #### Verify security status
   ```
   make audit
   # Run all relevant tests
   cargo test core::platform core::binary
   # Verify static linking
   otool -L target/release/setup-devbox | grep lzma # Should be empty
   ```